### PR TITLE
Hide cart access for seller roles

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,25 @@
+# Mini Marketplace Frontend
+
+Giao diện Next.js để thao tác với hệ thống backend trong thư mục `api-gateway`. Ứng dụng tập trung vào các luồng cơ bản đã được mô tả trong tài liệu OpenAPI (đăng nhập, quản lý sản phẩm và đơn hàng).
+
+## Khởi chạy cục bộ
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Ứng dụng sử dụng biến môi trường `NEXT_PUBLIC_API_BASE_URL` để xác định địa chỉ API Gateway. Mặc định là `http://localhost:8080`. Ngoài ra cần khai báo `NEXT_PUBLIC_JWT_SECRET` (hoặc tương đương) để frontend có thể giải mã và gia hạn access token dựa trên refresh token.
+
+## Cấu trúc chính
+
+- `app/` – cấu trúc App Router của Next.js với các trang đăng nhập, đăng ký, danh sách sản phẩm và bảng điều khiển.
+- `components/` – các thành phần tái sử dụng như thanh điều hướng, form tạo sản phẩm/đơn hàng và lớp bảo vệ yêu cầu đăng nhập.
+- `lib/api.ts` – wrapper đơn giản cho các endpoint của API Gateway dựa trên tài liệu OpenAPI.
+
+## Giao diện
+
+Dự án sử dụng **Tailwind CSS** cho toàn bộ lớp trình bày. Các tiện ích tùy chỉnh được áp dụng thông qua `@apply` trong `app/globals.css`, giúp tái sử dụng các pattern như `card`, nút hành động và input nhất quán trên toàn ứng dụng. Khi mở rộng giao diện bạn chỉ cần kết hợp các utility class của Tailwind hoặc bổ sung thêm lớp tùy chỉnh trong cùng tệp.
+
+> Lưu ý: Các yêu cầu tới API cần Bearer Token. Sau khi đăng nhập thành công, token sẽ được lưu trong `localStorage`, tự động gia hạn bằng refresh token khi sắp hết hạn và gửi kèm ID người dùng cho các lời gọi kế tiếp.

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '../../../components/auth/AuthProvider';
+import type { LoginInput, Role } from '../../../lib/types';
+
+const roles: Role[] = ['buyer', 'seller_admin', 'seller_employee'];
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [formState, setFormState] = useState<LoginInput>({
+    username: '',
+    password: '',
+    role: 'buyer'
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await login(formState);
+      router.push('/');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className="card mx-auto grid max-w-md gap-4" onSubmit={handleSubmit}>
+      <h1 className="text-3xl font-bold text-slate-900">Đăng nhập</h1>
+      <p className="text-sm text-slate-600">Sử dụng thông tin tài khoản đã được cấp để đăng nhập.</p>
+      <label>
+        Tên đăng nhập
+        <input
+          type="text"
+          value={formState.username}
+          onChange={(event) => setFormState((prev) => ({ ...prev, username: event.target.value }))}
+          required
+        />
+      </label>
+      <label>
+        Mật khẩu
+        <input
+          type="password"
+          value={formState.password}
+          onChange={(event) => setFormState((prev) => ({ ...prev, password: event.target.value }))}
+          required
+        />
+      </label>
+      <label>
+        Vai trò
+        <select
+          value={formState.role}
+          onChange={(event) => setFormState((prev) => ({ ...prev, role: event.target.value as Role }))}
+          className="w-full rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          {roles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {loading ? 'Đang đăng nhập...' : 'Đăng nhập'}
+      </button>
+      {error ? <p className="text-sm font-medium text-rose-600">{error}</p> : null}
+    </form>
+  );
+}

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '../../../components/auth/AuthProvider';
+import type { RegisterInput, Role } from '../../../lib/types';
+
+const roles: Role[] = ['buyer', 'seller_admin', 'seller_employee'];
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { register } = useAuth();
+  const [formState, setFormState] = useState<RegisterInput>({
+    username: '',
+    password: '',
+    role: 'buyer'
+  });
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    try {
+      const response = await register(formState);
+      setMessage(response.message ?? 'Đăng ký thành công. Vui lòng đăng nhập.');
+      setTimeout(() => {
+        router.push('/login');
+      }, 800);
+    } catch (err) {
+      setMessage((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className="card mx-auto grid max-w-md gap-4" onSubmit={handleSubmit}>
+      <h1 className="text-3xl font-bold text-slate-900">Tạo tài khoản</h1>
+      <label>
+        Tên đăng nhập
+        <input
+          type="text"
+          value={formState.username}
+          onChange={(event) => setFormState((prev) => ({ ...prev, username: event.target.value }))}
+          required
+        />
+      </label>
+      <label>
+        Mật khẩu
+        <input
+          type="password"
+          value={formState.password}
+          onChange={(event) => setFormState((prev) => ({ ...prev, password: event.target.value }))}
+          required
+        />
+      </label>
+      <label>
+        Vai trò
+        <select
+          value={formState.role}
+          onChange={(event) => setFormState((prev) => ({ ...prev, role: event.target.value as Role }))}
+          className="w-full rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          {roles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {loading ? 'Đang xử lý...' : 'Đăng ký'}
+      </button>
+      {message ? <p className="text-sm text-slate-700">{message}</p> : null}
+    </form>
+  );
+}

--- a/frontend/app/cart/CartPageClient.tsx
+++ b/frontend/app/cart/CartPageClient.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createOrderRequest } from '../../lib/api';
+import type { CartEntry } from '../../lib/types';
+import { useAuth } from '../../components/auth/AuthProvider';
+import { useCart } from '../../components/cart/CartProvider';
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(value);
+}
+
+function formatAttributeValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => formatAttributeValue(item)).join(', ');
+  }
+  if (value && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, val]) => `${key}: ${formatAttributeValue(val)}`)
+      .join('; ');
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Có' : 'Không';
+  }
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  return String(value);
+}
+
+function CartItemCard({ entry, onQuantityChange, onRemove, canModify }: {
+  entry: CartEntry;
+  onQuantityChange: (quantity: number) => void;
+  onRemove: () => void;
+  canModify: boolean;
+}) {
+  const { product, quantity } = entry;
+  const attributes = product.attributes ?? {};
+  const attributeEntries = Object.entries(attributes);
+
+  return (
+    <article className="card grid gap-3 border border-slate-200 bg-white shadow-none">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">{product.name}</h3>
+          <p className="text-sm text-slate-500">Mã sản phẩm: {product.id}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={!canModify}
+          className={`rounded-xl border px-3 py-1.5 text-sm font-semibold transition ${
+            canModify
+              ? 'border-rose-300 text-rose-600 hover:bg-rose-50'
+              : 'border-rose-100 text-rose-300 cursor-not-allowed'
+          }`}
+        >
+          Xóa
+        </button>
+      </header>
+      <div className="flex flex-wrap items-center gap-4 text-sm text-slate-700">
+        <span className="text-base font-semibold text-indigo-600">{formatCurrency(product.price ?? 0)}</span>
+        <span>Tồn kho: {product.inventory}</span>
+        <span>Người bán: {product.seller_id}</span>
+      </div>
+      <label className="inline-flex max-w-xs flex-col gap-1 text-sm font-semibold text-slate-700">
+        Số lượng
+        <input
+          type="number"
+          min={1}
+          value={quantity}
+          onChange={(event) => onQuantityChange(Math.max(1, Number(event.target.value) || 1))}
+          className="max-w-[120px] rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={!canModify}
+        />
+      </label>
+      {attributeEntries.length > 0 ? (
+        <dl className="grid gap-2 text-sm text-slate-700 sm:grid-cols-2 lg:grid-cols-3">
+          {attributeEntries.map(([key, value]) => (
+            <div key={key} className="rounded-xl bg-slate-50 px-3 py-2">
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{key}</dt>
+              <dd className="font-medium text-slate-800">{formatAttributeValue(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+      {!canModify ? (
+        <p className="text-sm font-medium text-rose-600">
+          Không thể thao tác vì sản phẩm thiếu mã định danh. Vui lòng làm mới dữ liệu.
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+export function CartPageClient() {
+  const router = useRouter();
+  const { accessToken, role, userId, getValidAccessToken } = useAuth();
+  const { items, totalPrice, totalQuantity, updateItemQuantity, removeItem, clearCart } = useCart();
+  const [status, setStatus] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const missingProductIds = items.some((entry) => typeof entry.product.id !== 'number');
+
+  const handleCheckout = async () => {
+    if (items.length === 0) {
+      setStatus('Giỏ hàng đang trống, hãy thêm sản phẩm trước khi thanh toán.');
+      return;
+    }
+
+    if (!accessToken) {
+      router.push('/login');
+      return;
+    }
+
+    if (!userId || userId <= 0) {
+      setStatus('Không thể xác định tài khoản hiện tại. Vui lòng đăng nhập lại.');
+      router.push('/login');
+      return;
+    }
+
+    if (missingProductIds) {
+      setStatus('Một số sản phẩm thiếu mã hợp lệ, vui lòng tải lại danh sách.');
+      return;
+    }
+
+    setLoading(true);
+    setStatus(null);
+
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        setStatus('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+        router.push('/login');
+        return;
+      }
+      const orderItems = items.map((entry) => ({
+        product_id: entry.product.id as number,
+        quantity: entry.quantity,
+        price: entry.product.price ?? 0,
+        name: entry.product.name
+      }));
+
+      const response = await createOrderRequest(
+        {
+          order: {
+            buyer_id: userId,
+            status: 'pending',
+            total_price: orderItems.reduce((total, item) => total + item.price * item.quantity, 0),
+            order_items: orderItems
+          }
+        },
+        token
+      );
+
+      setStatus(response.message ?? 'Đặt hàng thành công!');
+      clearCart();
+    } catch (error) {
+      setStatus((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6">
+      <header className="card grid gap-2">
+        <h1 className="text-2xl font-bold text-slate-900">Giỏ hàng của bạn</h1>
+        <p className="text-sm text-slate-600">
+          Tổng số lượng: <strong>{totalQuantity}</strong> sản phẩm | Tổng giá trị: <strong>{formatCurrency(totalPrice)}</strong>
+        </p>
+        <p className="text-sm text-slate-600">
+          Vai trò hiện tại: <strong>{role}</strong>
+        </p>
+        <p className="text-sm text-slate-600">
+          ID người dùng: <strong>{userId ?? 'Không xác định'}</strong>
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/products" className="font-semibold text-indigo-600 hover:text-indigo-500">
+            ← Tiếp tục mua sắm
+          </Link>
+        </div>
+      </header>
+
+      {missingProductIds ? (
+        <div className="card border border-rose-200 bg-rose-50 text-sm font-medium text-rose-700">
+          Một số sản phẩm trong giỏ không có mã định danh hợp lệ. Vui lòng tải lại danh sách sản phẩm hoặc thêm lại sản
+          phẩm để có thể thanh toán.
+        </div>
+      ) : null}
+
+      {items.length === 0 ? (
+        <div className="card text-sm text-slate-600">
+          Giỏ hàng trống. Hãy duyệt danh sách sản phẩm và thêm món bạn thích.
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {items.map((entry) => {
+            const hasValidId = typeof entry.product.id === 'number';
+            return (
+              <CartItemCard
+                key={`${entry.product.id}-${entry.product.name}`}
+                entry={entry}
+                canModify={hasValidId}
+                onQuantityChange={(quantity) => {
+                  if (hasValidId) {
+                    updateItemQuantity(entry.product.id as number, Math.max(1, quantity));
+                  }
+                }}
+                onRemove={() => {
+                  if (hasValidId) {
+                    removeItem(entry.product.id as number);
+                  }
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <section className="card grid gap-3">
+        <h2 className="text-xl font-semibold text-slate-900">Thanh toán</h2>
+        <p className="text-sm text-slate-600">
+          Đơn hàng sẽ được tạo cho tài khoản có ID <strong>{userId && userId > 0 ? userId : 'Không xác định'}</strong>.
+        </p>
+        <button
+          type="button"
+          onClick={handleCheckout}
+          disabled={loading || items.length === 0 || !userId}
+          className="rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {loading ? 'Đang xử lý...' : 'Checkout (tạo đơn hàng)'}
+        </button>
+        {status ? <p className="text-sm text-slate-700">{status}</p> : null}
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedContent } from '../../components/ProtectedContent';
+import { CartPageClient } from './CartPageClient';
+
+export default function CartPage() {
+  return (
+    <ProtectedContent allowedRoles={['buyer']}>
+      <CartPageClient />
+    </ProtectedContent>
+  );
+}

--- a/frontend/app/dashboard/DashboardContent.tsx
+++ b/frontend/app/dashboard/DashboardContent.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useAuth } from '../../components/auth/AuthProvider';
+import { CreateProductForm } from '../../components/CreateProductForm';
+
+export function DashboardContent() {
+  const { username, role } = useAuth();
+  const isSeller = role === 'seller_admin' || role === 'seller_employee';
+  const isBuyer = role === 'buyer';
+
+  return (
+    <div className="grid gap-6">
+      <header className="card grid gap-2">
+        <h1 className="text-2xl font-bold text-slate-900">Bảng điều khiển</h1>
+        <p className="text-sm text-slate-600">
+          Đăng nhập bởi <strong>{username}</strong> với vai trò <strong>{role}</strong>.
+        </p>
+      </header>
+      {isSeller ? (
+        <CreateProductForm />
+      ) : (
+        <div className="card grid gap-2">
+          <h2 className="text-xl font-semibold text-slate-900">Quản lý sản phẩm</h2>
+          <p className="text-sm text-slate-600">
+            Chỉ tài khoản <strong>seller_admin</strong> hoặc <strong>seller_employee</strong> mới có quyền tạo và chỉnh sửa sản
+            phẩm. Vui lòng đăng nhập bằng tài khoản người bán nếu bạn cần truy cập tính năng này.
+          </p>
+        </div>
+      )}
+      <div className="card grid gap-2">
+        <h2 className="text-xl font-semibold text-slate-900">Đơn hàng</h2>
+        {isBuyer ? (
+          <p className="text-sm text-slate-600">
+            Thêm sản phẩm vào giỏ hàng từ trang <strong>Sản phẩm</strong>, sau đó truy cập mục <strong>Giỏ hàng</strong> để hoàn
+            tất đơn hàng.
+          </p>
+        ) : (
+          <p className="text-sm text-slate-600">
+            Chỉ tài khoản người mua mới có thể tạo đơn hàng. Bạn vẫn có thể theo dõi các yêu cầu mua hàng của khách trong hệ
+            thống quản trị hoặc xem sản phẩm của mình tại mục <strong>Sản phẩm của tôi</strong>.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedContent } from '../../components/ProtectedContent';
+import { DashboardContent } from './DashboardContent';
+
+export default function DashboardPage() {
+  return (
+    <ProtectedContent allowedRoles={['seller_admin', 'seller_employee']}>
+      <DashboardContent />
+    </ProtectedContent>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,41 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply min-h-screen bg-gradient-to-b from-zinc-100 to-white font-sans text-slate-900 antialiased;
+}
+
+a {
+  @apply text-inherit no-underline;
+}
+
+button {
+  @apply cursor-pointer;
+}
+
+main {
+  @apply mx-auto w-full max-w-5xl px-4 py-8 md:px-8 md:py-12;
+}
+
+form {
+  @apply grid gap-4;
+}
+
+label {
+  @apply grid gap-1 text-sm font-semibold text-slate-700;
+}
+
+input,
+select,
+textarea {
+  @apply w-full rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200;
+}
+
+.card {
+  @apply rounded-2xl bg-white p-6 shadow-xl shadow-slate-900/10;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { Providers } from '../components/Providers';
+import { NavBar } from '../components/NavBar';
+
+export const metadata: Metadata = {
+  title: 'Mini Marketplace',
+  description: 'Frontend for the mini marketplace platform powered by the Go services.',
+  icons: {
+    icon: '/favicon.ico'
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gradient-to-b from-zinc-100 to-white font-sans text-slate-900 antialiased">
+        <Providers>
+          <NavBar />
+          <main className="w-full">{children}</main>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/orders/OrdersPageClient.tsx
+++ b/frontend/app/orders/OrdersPageClient.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../../components/auth/AuthProvider';
+import { getOrdersByBuyerStatusRequest } from '../../lib/api';
+import type { Order, OrderStatus } from '../../lib/types';
+
+const STATUS_META: Record<OrderStatus, { label: string; description: string; badgeClass: string }> = {
+  PENDING: {
+    label: 'Đang chờ',
+    description: 'Các đơn hàng đang được xử lý.',
+    badgeClass: 'bg-amber-100 text-amber-700'
+  },
+  FAILED: {
+    label: 'Thất bại',
+    description: 'Đơn hàng không thể hoàn tất.',
+    badgeClass: 'bg-rose-100 text-rose-700'
+  },
+  SUCCESS: {
+    label: 'Thành công',
+    description: 'Đơn hàng đã thanh toán thành công.',
+    badgeClass: 'bg-emerald-100 text-emerald-700'
+  },
+  VALID: {
+    label: 'Hợp lệ',
+    description: 'Đơn hàng đã được xác nhận hợp lệ.',
+    badgeClass: 'bg-sky-100 text-sky-700'
+  },
+  CANCELED: {
+    label: 'Đã hủy',
+    description: 'Đơn hàng đã bị hủy.',
+    badgeClass: 'bg-slate-200 text-slate-700'
+  }
+};
+
+const statusOptions: OrderStatus[] = ['PENDING', 'FAILED', 'SUCCESS', 'VALID', 'CANCELED'];
+
+const currencyFormatter = new Intl.NumberFormat('vi-VN', {
+  style: 'currency',
+  currency: 'VND'
+});
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function formatCurrency(value: unknown): string {
+  const numeric = toNumber(value);
+  if (numeric === null) {
+    return 'Không xác định';
+  }
+  return currencyFormatter.format(numeric);
+}
+
+export function OrdersPageClient() {
+  const { userId, getValidAccessToken } = useAuth();
+  const [selectedStatus, setSelectedStatus] = useState<OrderStatus>('PENDING');
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      if (!userId) {
+        if (!cancelled) {
+          setOrders([]);
+          setError('Không tìm thấy thông tin người dùng. Vui lòng đăng nhập lại.');
+          setLoading(false);
+        }
+        return;
+      }
+
+      if (!cancelled) {
+        setLoading(true);
+        setError(null);
+      }
+
+      try {
+        const token = await getValidAccessToken();
+        if (!token) {
+          throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+        }
+        const response = await getOrdersByBuyerStatusRequest(userId, selectedStatus, token);
+        if (!cancelled) {
+          setOrders(response.orders ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedStatus, userId, getValidAccessToken]);
+
+  const statusDescription = useMemo(() => STATUS_META[selectedStatus]?.description ?? '', [selectedStatus]);
+
+  return (
+    <div className="grid gap-6">
+      <header className="card space-y-4">
+        <div className="grid gap-1">
+          <h1 className="text-2xl font-bold text-slate-900">Đơn hàng của bạn</h1>
+          <p className="text-sm text-slate-600">Chọn trạng thái để xem các đơn hàng tương ứng.</p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          {statusOptions.map((status) => {
+            const isActive = status === selectedStatus;
+            const meta = STATUS_META[status];
+            return (
+              <button
+                key={status}
+                type="button"
+                onClick={() => setSelectedStatus(status)}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                  isActive
+                    ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-200 focus-visible:outline-indigo-600'
+                    : 'border border-slate-300 text-slate-700 hover:bg-slate-100 focus-visible:outline-slate-400'
+                }`}
+                aria-pressed={isActive}
+              >
+                {meta.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-sm text-slate-500">{statusDescription}</p>
+      </header>
+
+      {loading ? <p className="text-sm text-slate-600">Đang tải đơn hàng...</p> : null}
+      {error ? (
+        <div className="card border border-rose-200 bg-rose-50 text-sm font-medium text-rose-700">
+          <strong className="font-semibold">Lỗi:</strong> {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5">
+        {orders.map((order, index) => {
+          const normalizedStatus = typeof order.status === 'string'
+            ? (order.status.toUpperCase() as OrderStatus)
+            : undefined;
+          const status = normalizedStatus && STATUS_META[normalizedStatus] ? normalizedStatus : selectedStatus;
+          const meta = STATUS_META[status];
+          const total = formatCurrency(order.total_price);
+          const items = Array.isArray(order.order_items) ? order.order_items : [];
+
+          return (
+            <article key={order.id ?? `${status}-${index}`} className="card space-y-4">
+              <header className="flex flex-wrap items-center justify-between gap-3">
+                <div className="grid gap-1">
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Đơn hàng #{order.id ?? '—'}
+                  </h2>
+                  <p className="text-sm text-slate-500">Tổng tiền: {total}</p>
+                </div>
+                <span className={`rounded-full px-3 py-1 text-sm font-semibold ${meta.badgeClass}`}>{meta.label}</span>
+              </header>
+
+              <div className="grid gap-3">
+                {items.length === 0 ? (
+                  <p className="rounded-xl border border-dashed border-slate-300 p-4 text-sm text-slate-500">
+                    Đơn hàng này chưa có thông tin sản phẩm.
+                  </p>
+                ) : (
+                  items.map((item) => {
+                    const unitPrice = formatCurrency(item.price);
+                    const quantityNumber = toNumber(item.quantity) ?? 0;
+                    const itemTotal = formatCurrency((toNumber(item.price) ?? 0) * quantityNumber);
+                    return (
+                      <div
+                        key={`${order.id ?? 'order'}-${item.product_id}-${item.id ?? 'item'}`}
+                        className="rounded-xl border border-slate-200 p-4"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-2">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-800">
+                              {item.name ?? `Sản phẩm #${item.product_id}`}
+                            </p>
+                            <p className="text-xs text-slate-500">Mã sản phẩm: {item.product_id}</p>
+                          </div>
+                          <div className="text-right text-sm text-slate-600">
+                            <p>Đơn giá: {unitPrice}</p>
+                            <p>Số lượng: {quantityNumber}</p>
+                            <p className="font-semibold text-slate-800">Thành tiền: {itemTotal}</p>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </article>
+          );
+        })}
+
+        {!loading && !error && orders.length === 0 ? (
+          <div className="card text-sm text-slate-600">
+            Không có đơn hàng nào trong trạng thái này.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/orders/OrdersPageClient.tsx
+++ b/frontend/app/orders/OrdersPageClient.tsx
@@ -20,20 +20,10 @@ const STATUS_META: Record<OrderStatus, { label: string; description: string; bad
     label: 'Thành công',
     description: 'Đơn hàng đã thanh toán thành công.',
     badgeClass: 'bg-emerald-100 text-emerald-700'
-  },
-  VALID: {
-    label: 'Hợp lệ',
-    description: 'Đơn hàng đã được xác nhận hợp lệ.',
-    badgeClass: 'bg-sky-100 text-sky-700'
-  },
-  CANCELED: {
-    label: 'Đã hủy',
-    description: 'Đơn hàng đã bị hủy.',
-    badgeClass: 'bg-slate-200 text-slate-700'
   }
 };
 
-const statusOptions: OrderStatus[] = ['PENDING', 'FAILED', 'SUCCESS', 'VALID', 'CANCELED'];
+const statusOptions: OrderStatus[] = ['PENDING', 'FAILED', 'SUCCESS'];
 
 const currencyFormatter = new Intl.NumberFormat('vi-VN', {
   style: 'currency',

--- a/frontend/app/orders/page.tsx
+++ b/frontend/app/orders/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedContent } from '../../components/ProtectedContent';
+import { OrdersPageClient } from './OrdersPageClient';
+
+export default function OrdersPage() {
+  return (
+    <ProtectedContent allowedRoles={['buyer']}>
+      <OrdersPageClient />
+    </ProtectedContent>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <div className="grid gap-8">
+      <section className="card grid gap-6 bg-gradient-to-tr from-indigo-500 to-violet-500 text-white">
+        <div className="grid gap-3">
+          <h1 className="text-4xl font-extrabold">Mini Marketplace</h1>
+          <p className="text-base leading-relaxed md:text-lg">
+            Trải nghiệm giao diện web hiện đại cho hệ thống marketplace của bạn. Đăng ký, quản lý sản phẩm và tạo
+            đơn hàng chỉ với vài cú click.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/register"
+            className="rounded-xl bg-slate-900 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-slate-800"
+          >
+            Bắt đầu ngay
+          </Link>
+          <Link
+            href="/products"
+            className="rounded-xl border border-white/60 px-5 py-2.5 font-semibold text-white transition hover:bg-white/10"
+          >
+            Khám phá sản phẩm
+          </Link>
+        </div>
+      </section>
+      <section className="grid gap-4">
+        <h2 className="text-2xl font-bold text-slate-900">Tính năng chính</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <article className="card">
+            <h3 className="text-lg font-semibold text-slate-900">Đăng nhập & phân quyền</h3>
+            <p className="text-sm text-slate-600">
+              Hỗ trợ đăng nhập với đầy đủ vai trò <strong>buyer</strong>, <strong>seller_admin</strong> và
+              <strong> seller_employee</strong>. Phiên đăng nhập được lưu trữ an toàn để sử dụng cho các yêu cầu cần xác
+              thực.
+            </p>
+          </article>
+          <article className="card">
+            <h3 className="text-lg font-semibold text-slate-900">Quản lý sản phẩm</h3>
+            <p className="text-sm text-slate-600">
+              Người bán có thể tạo mới, cập nhật và xem chi tiết sản phẩm với phần thuộc tính hiển thị đẹp mắt, dễ đọc.
+            </p>
+          </article>
+          <article className="card">
+            <h3 className="text-lg font-semibold text-slate-900">Giỏ hàng & đơn hàng</h3>
+            <p className="text-sm text-slate-600">
+              Thêm sản phẩm vào giỏ, chỉnh số lượng theo nhu cầu rồi hoàn tất thanh toán chỉ với vài thao tác.
+            </p>
+          </article>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/products/ProductsPageClient.tsx
+++ b/frontend/app/products/ProductsPageClient.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getProductsRequest } from '../../lib/api';
+import type { Product } from '../../lib/types';
+import { useAuth } from '../../components/auth/AuthProvider';
+import { ProductCard } from '../../components/ProductCard';
+
+export function ProductsPageClient() {
+  const { accessToken, getValidAccessToken } = useAuth();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = await getValidAccessToken();
+        if (!token) {
+          throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+        }
+        const response = await getProductsRequest(page, 12, token);
+        if (!cancelled) {
+          setProducts(response.products ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [page, accessToken, getValidAccessToken]);
+
+  return (
+    <div className="grid gap-6">
+      <header className="card flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="grid gap-1">
+          <h1 className="text-2xl font-bold text-slate-900">Danh sách sản phẩm</h1>
+          <p className="text-sm text-slate-600">Bạn cần đăng nhập để xem và mua hàng.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+            className="rounded-xl border border-slate-300 px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={page === 1}
+          >
+            Trang trước
+          </button>
+          <span className="font-semibold text-slate-700">Trang {page}</span>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => prev + 1)}
+            className="rounded-xl border border-slate-300 px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-100"
+          >
+            Trang sau
+          </button>
+        </div>
+      </header>
+      {loading ? <p className="text-sm text-slate-600">Đang tải sản phẩm...</p> : null}
+      {error ? (
+        <div className="card border border-rose-200 bg-rose-50 text-sm font-medium text-rose-700">
+          <strong className="font-semibold">Lỗi:</strong> {error}
+        </div>
+      ) : null}
+      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        {products.map((product) => (
+          <ProductCard key={product.id ?? product.name} product={product} />
+        ))}
+        {!loading && products.length === 0 && !error ? (
+          <div className="card text-sm text-slate-600">
+            Không có sản phẩm để hiển thị.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/products/[id]/ProductDetailsClient.tsx
+++ b/frontend/app/products/[id]/ProductDetailsClient.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getProductByIdRequest } from '../../../lib/api';
+import type { Product } from '../../../lib/types';
+import { useAuth } from '../../../components/auth/AuthProvider';
+import { AddToCartControl } from '../../../components/AddToCartControl';
+
+interface Props {
+  productId: number;
+}
+
+export function ProductDetailsClient({ productId }: Props) {
+  const { accessToken, getValidAccessToken } = useAuth();
+  const [product, setProduct] = useState<Product | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = await getValidAccessToken();
+        if (!token) {
+          throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+        }
+        const response = await getProductByIdRequest(productId, token);
+        if (!cancelled) {
+          setProduct(response.product ?? null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [productId, accessToken, getValidAccessToken]);
+
+  if (loading) {
+    return <p className="text-sm text-slate-600">Đang tải thông tin sản phẩm...</p>;
+  }
+
+  if (error) {
+    return (
+      <div className="card border border-rose-200 bg-rose-50 text-sm font-medium text-rose-700">
+        <strong className="font-semibold">Lỗi:</strong> {error}
+      </div>
+    );
+  }
+
+  if (!product) {
+    return <div className="card text-sm text-slate-600">Không tìm thấy sản phẩm.</div>;
+  }
+
+  const attributes = product.attributes ?? {};
+  const attributeEntries = Object.entries(attributes);
+
+  const formatAttributeValue = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return value.map((item) => formatAttributeValue(item)).join(', ');
+    }
+    if (value && typeof value === 'object') {
+      return Object.entries(value as Record<string, unknown>)
+        .map(([key, val]) => `${key}: ${formatAttributeValue(val)}`)
+        .join('; ');
+    }
+    if (typeof value === 'boolean') {
+      return value ? 'Có' : 'Không';
+    }
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return String(value);
+  };
+
+  return (
+    <article className="card grid gap-6">
+      <header className="grid gap-1">
+        <h1 className="text-3xl font-bold text-slate-900">{product.name}</h1>
+        <p className="text-sm text-slate-500">Mã sản phẩm: {product.id}</p>
+      </header>
+      <div className="flex flex-wrap items-center gap-4 text-sm text-slate-700">
+        <span className="text-2xl font-semibold text-indigo-600">
+          {new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(product.price)}
+        </span>
+        <span>Tồn kho: {product.inventory}</span>
+        <span>Người bán: {product.seller_id}</span>
+      </div>
+      <AddToCartControl product={product} />
+      {attributeEntries.length > 0 ? (
+        <section className="grid gap-3">
+          <h2 className="text-xl font-semibold text-slate-900">Thuộc tính sản phẩm</h2>
+          <dl className="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-3">
+            {attributeEntries.map(([key, value]) => (
+              <div key={key} className="grid gap-2 rounded-xl bg-slate-50 px-4 py-3">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">{key}</dt>
+                <dd className="text-sm font-medium text-slate-800">{formatAttributeValue(value)}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      ) : null}
+    </article>
+  );
+}

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from 'next/navigation';
+import { ProductDetailsClient } from './ProductDetailsClient';
+
+interface Props {
+  params: { id: string };
+}
+
+export default function ProductDetailPage({ params }: Props) {
+  const id = Number(params.id);
+
+  if (Number.isNaN(id)) {
+    notFound();
+  }
+
+  return <ProductDetailsClient productId={id} />;
+}

--- a/frontend/app/products/mine/MyProductsPageClient.tsx
+++ b/frontend/app/products/mine/MyProductsPageClient.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ProductCard } from '../../../components/ProductCard';
+import { useAuth } from '../../../components/auth/AuthProvider';
+import { getProductsBySellerRequest } from '../../../lib/api';
+import type { Product } from '../../../lib/types';
+
+export function MyProductsPageClient() {
+  const { userId, getValidAccessToken } = useAuth();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (userId === null) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (!userId || userId <= 0) {
+      setProducts([]);
+      setLoading(false);
+      setError('Không tìm thấy mã người bán hợp lệ. Vui lòng đăng nhập lại.');
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = await getValidAccessToken();
+        if (!token) {
+          throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+        }
+        const response = await getProductsBySellerRequest(userId, token);
+        if (!cancelled) {
+          setProducts(response.products ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, getValidAccessToken]);
+
+  return (
+    <div className="grid gap-6">
+      <header className="card grid gap-2">
+        <h1 className="text-2xl font-bold text-slate-900">Sản phẩm của tôi</h1>
+        <p className="text-sm text-slate-600">Toàn bộ sản phẩm gắn với tài khoản người bán hiện tại.</p>
+      </header>
+      {loading ? <p className="text-sm text-slate-600">Đang tải sản phẩm của bạn...</p> : null}
+      {error ? (
+        <div className="card border border-rose-200 bg-rose-50 text-sm font-medium text-rose-700">
+          <strong className="font-semibold">Lỗi:</strong> {error}
+        </div>
+      ) : null}
+      <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        {products.map((product) => (
+          <ProductCard key={product.id ?? product.name} product={product} />
+        ))}
+        {!loading && products.length === 0 && !error ? (
+          <div className="card text-sm text-slate-600">Bạn chưa có sản phẩm nào.</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/products/mine/page.tsx
+++ b/frontend/app/products/mine/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedContent } from '../../../components/ProtectedContent';
+import { MyProductsPageClient } from './MyProductsPageClient';
+
+export default function MyProductsPage() {
+  return (
+    <ProtectedContent allowedRoles={['seller_admin', 'seller_employee']}>
+      <MyProductsPageClient />
+    </ProtectedContent>
+  );
+}

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -1,0 +1,5 @@
+import { ProductsPageClient } from './ProductsPageClient';
+
+export default function ProductsPage() {
+  return <ProductsPageClient />;
+}

--- a/frontend/components/AddToCartControl.tsx
+++ b/frontend/components/AddToCartControl.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Product } from '../lib/types';
+import { useAuth } from './auth/AuthProvider';
+import { useCart } from './cart/CartProvider';
+
+interface Props {
+  product: Product;
+  buttonVariant?: 'solid' | 'ghost';
+}
+
+export function AddToCartControl({ product, buttonVariant = 'solid' }: Props) {
+  const router = useRouter();
+  const { accessToken, getValidAccessToken, role } = useAuth();
+  const { addItem } = useCart();
+  const [isPromptOpen, setPromptOpen] = useState(false);
+  const [quantity, setQuantity] = useState(1);
+  const [status, setStatus] = useState<{ message: string; tone: 'success' | 'error' } | null>(null);
+
+  if (role && role !== 'buyer') {
+    return null;
+  }
+
+  const ensureProductId = () => {
+    if (typeof product.id !== 'number') {
+      setStatus({ message: 'Sản phẩm chưa có mã hợp lệ, không thể thêm vào giỏ.', tone: 'error' });
+      return false;
+    }
+    return true;
+  };
+
+  const openPrompt = async () => {
+    if (!accessToken) {
+      setStatus({ message: 'Vui lòng đăng nhập để thêm sản phẩm vào giỏ hàng.', tone: 'error' });
+      router.push('/login');
+      return;
+    }
+
+    const token = await getValidAccessToken();
+    if (!token) {
+      setStatus({ message: 'Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.', tone: 'error' });
+      router.push('/login');
+      return;
+    }
+    if (!ensureProductId()) {
+      return;
+    }
+    setStatus(null);
+    setQuantity(1);
+    setPromptOpen(true);
+  };
+
+  const handleAddToCart = () => {
+    if (!ensureProductId()) {
+      return;
+    }
+
+    addItem(product, quantity);
+    setPromptOpen(false);
+    setStatus({ message: 'Đã thêm sản phẩm vào giỏ hàng.', tone: 'success' });
+  };
+
+  const buttonClass =
+    buttonVariant === 'ghost'
+      ? 'w-full rounded-xl border border-slate-300 px-5 py-2.5 font-semibold text-indigo-600 transition hover:bg-indigo-50 sm:w-auto'
+      : 'w-full rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:w-auto';
+
+  return (
+    <div className="grid gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          void openPrompt();
+        }}
+        className={buttonClass}
+      >
+        Thêm vào giỏ hàng
+      </button>
+      {isPromptOpen ? (
+        <div className="card grid gap-3 border border-indigo-200 bg-indigo-50 shadow-none">
+          <label>
+            Số lượng
+            <input
+              type="number"
+              min={1}
+              value={quantity}
+              onChange={(event) => setQuantity(Math.max(1, Number(event.target.value) || 1))}
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="w-full rounded-xl bg-indigo-600 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              onClick={handleAddToCart}
+            >
+              Xác nhận
+            </button>
+            <button
+              type="button"
+              onClick={() => setPromptOpen(false)}
+              className="w-full rounded-xl border border-slate-300 bg-white px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-100"
+            >
+              Hủy
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {status ? (
+        <span
+          className={`text-sm ${status.tone === 'success' ? 'text-emerald-600' : 'text-rose-600'}`}
+        >
+          {status.message}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/CreateOrderForm.tsx
+++ b/frontend/components/CreateOrderForm.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createOrderRequest } from '../lib/api';
+import type { OrderItem } from '../lib/types';
+import { useAuth } from './auth/AuthProvider';
+
+export function CreateOrderForm() {
+  const { userId, getValidAccessToken } = useAuth();
+  const [buyerId, setBuyerId] = useState(0);
+  const [status, setStatus] = useState('pending');
+  const [items, setItems] = useState<OrderItem[]>([
+    { product_id: 0, quantity: 1, price: 0 }
+  ]);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (userId && userId > 0) {
+      setBuyerId(userId);
+    }
+  }, [userId]);
+
+  const updateItem = (index: number, patch: Partial<OrderItem>) => {
+    setItems((prev) => prev.map((item, idx) => (idx === index ? { ...item, ...patch } : item)));
+  };
+
+  const addItem = () => {
+    setItems((prev) => [...prev, { product_id: 0, quantity: 1, price: 0 }]);
+  };
+
+  const removeItem = (index: number) => {
+    setItems((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+      }
+      const totalPrice = items.reduce((total, item) => total + item.price * item.quantity, 0);
+      const result = await createOrderRequest(
+        {
+          order: {
+            buyer_id: buyerId,
+            status,
+            total_price: totalPrice,
+            order_items: items
+          }
+        },
+        token
+      );
+      setMessage(result.message ?? 'Tạo đơn hàng thành công');
+    } catch (error) {
+      setMessage((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className="card grid gap-4" onSubmit={handleSubmit}>
+      <h2 className="text-2xl font-bold text-slate-900">Tạo đơn hàng</h2>
+      <label>
+        Mã người mua
+        <input
+          type="number"
+          value={buyerId}
+          min={1}
+          onChange={(event) => setBuyerId(Number(event.target.value) || 0)}
+          required
+        />
+      </label>
+      <label>
+        Trạng thái
+        <select
+          value={status}
+          onChange={(event) => setStatus(event.target.value)}
+          className="w-full rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+        >
+          <option value="pending">pending</option>
+          <option value="processing">processing</option>
+          <option value="completed">completed</option>
+          <option value="cancelled">cancelled</option>
+        </select>
+      </label>
+      <div className="grid gap-4">
+        <h3 className="text-lg font-semibold text-slate-900">Sản phẩm trong đơn</h3>
+        {items.map((item, index) => (
+          <div key={index} className="card grid gap-3 border border-slate-200 bg-slate-50 p-4 shadow-none">
+            <label>
+              Mã sản phẩm
+              <input
+                type="number"
+                min={1}
+                value={item.product_id}
+                onChange={(event) => updateItem(index, { product_id: Number(event.target.value) || 0 })}
+                required
+              />
+            </label>
+            <label>
+              Số lượng
+              <input
+                type="number"
+                min={1}
+                value={item.quantity}
+                onChange={(event) => updateItem(index, { quantity: Number(event.target.value) || 1 })}
+                required
+              />
+            </label>
+            <label>
+              Đơn giá
+              <input
+                type="number"
+                min={0}
+                step={1000}
+                value={item.price}
+                onChange={(event) => updateItem(index, { price: Number(event.target.value) || 0 })}
+                required
+              />
+            </label>
+            {items.length > 1 ? (
+              <button
+                type="button"
+                onClick={() => removeItem(index)}
+                className="w-full rounded-xl border border-rose-200 bg-white px-4 py-2 font-semibold text-rose-600 transition hover:bg-rose-50"
+              >
+                Xóa
+              </button>
+            ) : null}
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={addItem}
+          className="rounded-xl border border-dashed border-indigo-400 px-4 py-2 font-semibold text-indigo-600 transition hover:bg-indigo-50"
+        >
+          Thêm sản phẩm
+        </button>
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {loading ? 'Đang xử lý...' : 'Tạo đơn hàng'}
+      </button>
+      {message ? <p className="text-sm text-slate-700">{message}</p> : null}
+    </form>
+  );
+}

--- a/frontend/components/CreateProductForm.tsx
+++ b/frontend/components/CreateProductForm.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { createProductRequest } from '../lib/api';
+import type { CreateProductInput } from '../lib/types';
+import { useAuth } from './auth/AuthProvider';
+
+type Step = 'form' | 'confirm';
+
+interface AttributeRow {
+  key: string;
+  value: string;
+}
+
+interface StatusState {
+  type: 'success' | 'error';
+  message: string;
+}
+
+function createEmptyAttribute(): AttributeRow {
+  return { key: '', value: '' };
+}
+
+export function CreateProductForm() {
+  const { userId, getValidAccessToken } = useAuth();
+  const [formState, setFormState] = useState<Pick<CreateProductInput, 'name' | 'price' | 'inventory' | 'seller_id'>>({
+    name: '',
+    price: 0,
+    inventory: 0,
+    seller_id: 0
+  });
+  const [attributes, setAttributes] = useState<AttributeRow[]>([createEmptyAttribute()]);
+  const [step, setStep] = useState<Step>('form');
+  const [status, setStatus] = useState<StatusState | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (userId && userId > 0) {
+      setFormState((prev) => ({ ...prev, seller_id: userId }));
+    }
+  }, [userId]);
+
+  const sanitizedAttributes = useMemo(() => {
+    const entries = attributes
+      .map((attribute) => ({
+        key: attribute.key.trim(),
+        value: attribute.value
+      }))
+      .filter((attribute) => attribute.key.length > 0);
+
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    return entries.reduce<Record<string, string>>((result, attribute) => {
+      result[attribute.key] = attribute.value;
+      return result;
+    }, {});
+  }, [attributes]);
+
+  const resetForm = () => {
+    setFormState((previous) => ({
+      name: '',
+      price: 0,
+      inventory: 0,
+      seller_id: previous.seller_id
+    }));
+    setAttributes([createEmptyAttribute()]);
+  };
+
+  const validateForm = () => {
+    if (!formState.name.trim()) {
+      return 'Vui lòng nhập tên sản phẩm.';
+    }
+    if (!Number.isFinite(formState.price) || formState.price <= 0) {
+      return 'Giá sản phẩm phải lớn hơn 0.';
+    }
+    if (!Number.isFinite(formState.inventory) || formState.inventory < 0) {
+      return 'Số lượng tồn kho phải lớn hơn hoặc bằng 0.';
+    }
+    if (!Number.isFinite(formState.seller_id) || formState.seller_id <= 0) {
+      return 'Mã người bán không hợp lệ.';
+    }
+    return null;
+  };
+
+  const handleReview = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validationMessage = validateForm();
+    if (validationMessage) {
+      setStatus({ type: 'error', message: validationMessage });
+      return;
+    }
+
+    setStatus(null);
+    setStep('confirm');
+  };
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    setStatus(null);
+
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
+      }
+
+      const payload: CreateProductInput = {
+        ...formState,
+        attributes: sanitizedAttributes
+      };
+
+      const result = await createProductRequest(payload, token);
+      setStatus({ type: 'success', message: result.message ?? 'Tạo sản phẩm thành công.' });
+      resetForm();
+      setStep('form');
+    } catch (error) {
+      setStatus({ type: 'error', message: (error as Error).message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = () => {
+    setStep('form');
+    setStatus(null);
+  };
+
+  const updateAttribute = (index: number, field: keyof AttributeRow, value: string) => {
+    setAttributes((previous) =>
+      previous.map((attribute, attributeIndex) =>
+        attributeIndex === index ? { ...attribute, [field]: value } : attribute
+      )
+    );
+  };
+
+  const addAttribute = () => {
+    setAttributes((previous) => [...previous, createEmptyAttribute()]);
+  };
+
+  const removeAttribute = (index: number) => {
+    setAttributes((previous) => previous.filter((_, attributeIndex) => attributeIndex !== index));
+  };
+
+  return (
+    <div className="card grid gap-4">
+      {step === 'form' ? (
+        <form className="grid gap-4" onSubmit={handleReview}>
+          <h2 className="text-2xl font-bold text-slate-900">Tạo sản phẩm mới</h2>
+          <label className="grid gap-2 text-sm font-medium text-slate-700">
+            Tên sản phẩm
+            <input
+              type="text"
+              value={formState.name}
+              onChange={(event) => setFormState((prev) => ({ ...prev, name: event.target.value }))}
+              required
+            />
+          </label>
+          <label className="grid gap-2 text-sm font-medium text-slate-700">
+            Giá (VND)
+            <input
+              type="number"
+              value={formState.price}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, price: Number(event.target.value) || 0 }))
+              }
+              min={0}
+              step={1000}
+              required
+            />
+          </label>
+          <label className="grid gap-2 text-sm font-medium text-slate-700">
+            Số lượng tồn kho
+            <input
+              type="number"
+              value={formState.inventory}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, inventory: Number(event.target.value) || 0 }))
+              }
+              min={0}
+              required
+            />
+          </label>
+          <label className="grid gap-2 text-sm font-medium text-slate-700">
+            Mã người bán
+            <input
+              type="number"
+              value={formState.seller_id}
+              onChange={(event) =>
+                setFormState((prev) => ({ ...prev, seller_id: Number(event.target.value) || 0 }))
+              }
+              min={1}
+              required
+            />
+          </label>
+          <div className="grid gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-slate-700">Thuộc tính sản phẩm</span>
+              <button
+                type="button"
+                onClick={addAttribute}
+                className="rounded-xl border border-dashed border-indigo-400 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50"
+              >
+                Thêm thuộc tính
+              </button>
+            </div>
+            {attributes.map((attribute, index) => (
+              <div key={`attribute-${index}`} className="grid gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <div className="grid gap-3 sm:grid-cols-2 sm:gap-4">
+                  <label className="grid gap-1 text-sm font-medium text-slate-700">
+                    Tên thuộc tính
+                    <input
+                      type="text"
+                      value={attribute.key}
+                      onChange={(event) => updateAttribute(index, 'key', event.target.value)}
+                      placeholder="Ví dụ: Màu sắc"
+                    />
+                  </label>
+                  <label className="grid gap-1 text-sm font-medium text-slate-700">
+                    Giá trị
+                    <input
+                      type="text"
+                      value={attribute.value}
+                      onChange={(event) => updateAttribute(index, 'value', event.target.value)}
+                      placeholder="Ví dụ: Đỏ"
+                    />
+                  </label>
+                </div>
+                {attributes.length > 1 ? (
+                  <button
+                    type="button"
+                    onClick={() => removeAttribute(index)}
+                    className="w-full rounded-xl border border-rose-200 bg-white px-4 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50"
+                  >
+                    Xóa thuộc tính
+                  </button>
+                ) : null}
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <button
+              type="submit"
+              className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            >
+              Xem lại thông tin
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="grid gap-4">
+          <h2 className="text-2xl font-bold text-slate-900">Xác nhận tạo sản phẩm</h2>
+          <div className="grid gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            <div className="flex items-center justify-between">
+              <span className="text-slate-600">Tên sản phẩm</span>
+              <span className="font-semibold text-slate-900">{formState.name}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-600">Giá bán</span>
+              <span className="font-semibold text-slate-900">
+                {formState.price.toLocaleString('vi-VN')} VND
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-600">Tồn kho</span>
+              <span className="font-semibold text-slate-900">{formState.inventory}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-slate-600">Mã người bán</span>
+              <span className="font-semibold text-slate-900">{formState.seller_id}</span>
+            </div>
+            <div className="grid gap-2">
+              <span className="text-slate-600">Thuộc tính</span>
+              {sanitizedAttributes ? (
+                <ul className="grid gap-2">
+                  {Object.entries(sanitizedAttributes).map(([key, value]) => (
+                    <li
+                      key={key}
+                      className="flex items-start justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2"
+                    >
+                      <span className="font-medium text-slate-700">{key}</span>
+                      <span className="text-right text-slate-600">{String(value)}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <span className="text-slate-600">Không có thuộc tính bổ sung.</span>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={handleEdit}
+              disabled={loading}
+              className="rounded-xl border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Chỉnh sửa
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={loading}
+              className="rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {loading ? 'Đang tạo...' : 'Xác nhận tạo sản phẩm'}
+            </button>
+          </div>
+        </div>
+      )}
+      {status ? (
+        <p
+          className={`text-sm ${
+            status.type === 'error' ? 'text-rose-600' : 'text-emerald-600'
+          }`}
+        >
+          {status.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from './auth/AuthProvider';
+import { useCart } from './cart/CartProvider';
+import type { Role } from '../lib/types';
+
+interface NavLink {
+  href: string;
+  label: string;
+  requiresAuth: boolean;
+  hiddenForRoles?: Role[];
+}
+
+const baseLinks: NavLink[] = [
+  { href: '/', label: 'Trang chủ', requiresAuth: false },
+  { href: '/products', label: 'Sản phẩm', requiresAuth: false },
+  {
+    href: '/products/mine',
+    label: 'Sản phẩm của tôi',
+    requiresAuth: true,
+    hiddenForRoles: ['buyer']
+  },
+  {
+    href: '/orders',
+    label: 'Đơn hàng',
+    requiresAuth: true,
+    hiddenForRoles: ['seller_admin', 'seller_employee']
+  },
+  { href: '/dashboard', label: 'Bảng điều khiển', requiresAuth: true, hiddenForRoles: ['buyer'] }
+];
+
+export function NavBar() {
+  const pathname = usePathname();
+  const { accessToken, username, role, logout } = useAuth();
+  const { totalQuantity, clearCart } = useCart();
+
+  const handleLogout = () => {
+    clearCart();
+    logout();
+  };
+
+  const normalizedRole = role ?? null;
+  const showCartLink = !normalizedRole || normalizedRole === 'buyer';
+
+  return (
+    <header className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-5 md:px-8">
+      <Link href="/" className="text-xl font-bold text-slate-900">
+        Mini Marketplace
+      </Link>
+      <nav className="flex flex-wrap items-center gap-3 text-sm font-medium text-slate-700">
+        {baseLinks
+          .filter((link) => {
+            if (link.requiresAuth && !accessToken) {
+              return false;
+            }
+            if (
+              normalizedRole &&
+              link.hiddenForRoles &&
+              link.hiddenForRoles.length > 0 &&
+              link.hiddenForRoles.includes(normalizedRole)
+            ) {
+              return false;
+            }
+            return true;
+          })
+          .map((link) => {
+            const isActive = pathname === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-indigo-100 font-semibold text-indigo-900'
+                    : 'text-slate-700 hover:bg-slate-100'
+                }`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        {showCartLink ? (
+          <Link
+            href="/cart"
+            className={`flex items-center gap-2 rounded-full px-4 py-2 font-semibold transition ${
+              pathname === '/cart' ? 'bg-pink-100 text-pink-700' : 'bg-pink-50 text-pink-700 hover:bg-pink-100'
+            }`}
+          >
+            Giỏ hàng
+            <span className="flex min-w-6 items-center justify-center rounded-full bg-pink-600 px-2 text-xs font-semibold text-white">
+              {totalQuantity}
+            </span>
+          </Link>
+        ) : null}
+        {accessToken ? (
+          <div className="flex items-center gap-3 text-sm">
+            <span className="font-semibold text-slate-800">
+              Xin chào, {username}
+              {role ? ` (${role})` : ''}
+            </span>
+            <button
+              type="button"
+              className="rounded-xl bg-indigo-600 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              onClick={handleLogout}
+            >
+              Đăng xuất
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <Link
+              href="/login"
+              className="rounded-xl px-4 py-2 font-semibold text-indigo-600 transition hover:bg-indigo-50"
+            >
+              Đăng nhập
+            </Link>
+            <Link
+              href="/register"
+              className="rounded-xl px-4 py-2 font-semibold text-indigo-600 transition hover:bg-indigo-50"
+            >
+              Đăng ký
+            </Link>
+          </div>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/frontend/components/ProductCard.tsx
+++ b/frontend/components/ProductCard.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import type { Product } from '../lib/types';
+import { AddToCartControl } from './AddToCartControl';
+
+interface Props {
+  product: Product;
+}
+
+export function ProductCard({ product }: Props) {
+  
+  return (
+    <article className="card grid gap-4">
+      <div className="grid gap-2">
+        <div className="grid gap-1">
+          <h3 className="text-xl font-bold text-slate-900 break-words">{product.name}</h3>
+          <p className="text-sm text-slate-500">Mã sản phẩm: {product.id ?? 'Chưa xác định'}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-700">
+          <span className="text-lg font-semibold text-indigo-600">
+            {new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(product.price ?? 0)}
+          </span>
+          <span>Tồn kho: {product.inventory}</span>
+          <span>Người bán: {product.seller_id}</span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Link
+          href={`/products/${product.id}`}
+          className="font-semibold text-indigo-600 transition hover:text-indigo-500"
+        >
+          Xem chi tiết →
+        </Link>
+        <AddToCartControl product={product} buttonVariant="ghost" />
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/ProtectedContent.tsx
+++ b/frontend/components/ProtectedContent.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import { useAuth } from './auth/AuthProvider';
+import type { Role } from '../lib/types';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  allowedRoles?: Role[];
+}
+
+export function ProtectedContent({ children, fallback, allowedRoles }: Props) {
+  const { accessToken, role } = useAuth();
+
+  if (!accessToken) {
+    return (
+      <div className="card text-center">
+        {fallback ?? (
+          <>
+            <h2 className="text-xl font-semibold text-slate-900">Yêu cầu đăng nhập</h2>
+            <p className="text-sm text-slate-600">Vui lòng đăng nhập để sử dụng tính năng này.</p>
+            <div className="mt-4 flex items-center justify-center gap-4 text-sm font-semibold text-indigo-600">
+              <Link href="/login" className="rounded-xl px-4 py-2 transition hover:bg-indigo-50">
+                Đăng nhập
+              </Link>
+              <Link href="/register" className="rounded-xl px-4 py-2 transition hover:bg-indigo-50">
+                Đăng ký tài khoản
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  if (allowedRoles && allowedRoles.length > 0 && (!role || !allowedRoles.includes(role))) {
+    return (
+      <div className="card text-center">
+        <h2 className="text-xl font-semibold text-slate-900">Bạn không có quyền truy cập</h2>
+        <p className="text-sm text-slate-600">
+          Vui lòng đăng nhập với tài khoản có quyền phù hợp để sử dụng tính năng này.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/components/Providers.tsx
+++ b/frontend/components/Providers.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { AuthProvider } from './auth/AuthProvider';
+import { CartProvider } from './cart/CartProvider';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthProvider>
+      <CartProvider>{children}</CartProvider>
+    </AuthProvider>
+  );
+}

--- a/frontend/components/auth/AuthProvider.tsx
+++ b/frontend/components/auth/AuthProvider.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import type {
+  LoginInput,
+  LoginOutput,
+  RegisterInput,
+  RegisterOutput,
+  Role
+} from '../../lib/types';
+import { loginRequest, refreshTokenRequest, registerRequest } from '../../lib/api';
+import { decodeAuthToken, isTokenExpired } from '../../lib/jwt';
+
+export interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  username: string | null;
+  role: Role | null;
+  userId: number | null;
+  accessTokenExpiresAt: number | null;
+  refreshTokenExpiresAt: number | null;
+}
+
+interface AuthContextValue extends AuthState {
+  login: (input: LoginInput) => Promise<LoginOutput>;
+  register: (input: RegisterInput) => Promise<RegisterOutput>;
+  logout: () => void;
+  getValidAccessToken: () => Promise<string | null>;
+}
+
+const validRoles: Role[] = ['buyer', 'seller_admin', 'seller_employee'];
+
+const defaultState: AuthState = {
+  accessToken: null,
+  refreshToken: null,
+  username: null,
+  role: null,
+  userId: null,
+  accessTokenExpiresAt: null,
+  refreshTokenExpiresAt: null
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'mini-marketplace-auth';
+
+function isRole(value: unknown): value is Role {
+  return typeof value === 'string' && validRoles.includes(value as Role);
+}
+
+function deriveAuthState(partial: Partial<AuthState>): AuthState {
+  const accessToken = partial.accessToken ?? null;
+  const refreshToken = partial.refreshToken ?? null;
+  const decodedAccess = decodeAuthToken(accessToken);
+  const decodedRefresh = decodeAuthToken(refreshToken);
+
+  const fallbackRoleCandidate = partial.role ?? decodedRefresh.role ?? null;
+  const sanitizedFallbackRole = isRole(fallbackRoleCandidate) ? fallbackRoleCandidate : null;
+  const resolvedRole = decodedAccess.role ?? sanitizedFallbackRole;
+
+  return {
+    accessToken,
+    refreshToken,
+    username: decodedAccess.username ?? partial.username ?? decodedRefresh.username ?? null,
+    role: resolvedRole,
+    userId: decodedAccess.userId ?? partial.userId ?? decodedRefresh.userId ?? null,
+    accessTokenExpiresAt: decodedAccess.expiresAt ?? partial.accessTokenExpiresAt ?? null,
+    refreshTokenExpiresAt: decodedRefresh.expiresAt ?? partial.refreshTokenExpiresAt ?? null
+  };
+}
+
+function loadPersistedState(): AuthState {
+  if (typeof window === 'undefined') {
+    return defaultState;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return defaultState;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<AuthState>;
+    return deriveAuthState(parsed);
+  } catch (error) {
+    console.warn('Failed to parse auth state from storage', error);
+    return defaultState;
+  }
+}
+
+function persistState(state: AuthState) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('Failed to persist auth state', error);
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>(defaultState);
+  const refreshPromiseRef = useRef<Promise<string | null> | null>(null);
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const logout = useCallback(() => {
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = null;
+    }
+    refreshPromiseRef.current = null;
+    setState(defaultState);
+    persistState(defaultState);
+  }, []);
+
+  useEffect(() => {
+    setState(loadPersistedState());
+  }, []);
+
+  useEffect(() => {
+    if (state.refreshToken && isTokenExpired(state.refreshTokenExpiresAt, 0)) {
+      logout();
+    }
+  }, [state.refreshToken, state.refreshTokenExpiresAt, logout]);
+
+  const login = useCallback(async (input: LoginInput) => {
+    const output = await loginRequest(input);
+    const resolvedUserIdRaw =
+      typeof output.user_id === 'number'
+        ? output.user_id
+        : typeof output.user_id === 'string'
+          ? Number(output.user_id)
+          : null;
+    const resolvedUserId =
+      typeof resolvedUserIdRaw === 'number' && Number.isFinite(resolvedUserIdRaw)
+        ? resolvedUserIdRaw
+        : null;
+    const nextState = deriveAuthState({
+      accessToken: output.access_token ?? null,
+      refreshToken: output.refresh_token ?? null,
+      username: output.username ?? input.username,
+      role: output.role ?? input.role,
+      userId: resolvedUserId
+    });
+    setState(nextState);
+    persistState(nextState);
+    return output;
+  }, []);
+
+  const register = useCallback(async (input: RegisterInput) => {
+    return registerRequest(input);
+  }, []);
+
+  const refreshTokens = useCallback(async () => {
+    if (!state.refreshToken || isTokenExpired(state.refreshTokenExpiresAt, 0)) {
+      logout();
+      return null;
+    }
+
+    if (!refreshPromiseRef.current) {
+      refreshPromiseRef.current = (async () => {
+        try {
+          const response = await refreshTokenRequest(state.refreshToken as string);
+          let refreshedToken: string | null = response.access_token ?? null;
+          setState((previous) => {
+            const nextState = deriveAuthState({
+              ...previous,
+              accessToken: response.access_token ?? null,
+              refreshToken: response.refresh_token ?? previous.refreshToken
+            });
+            persistState(nextState);
+            refreshedToken = nextState.accessToken;
+            return nextState;
+          });
+          return refreshedToken;
+        } catch (error) {
+          console.warn('Failed to refresh tokens', error);
+          logout();
+          return null;
+        }
+      })();
+
+      refreshPromiseRef.current.finally(() => {
+        refreshPromiseRef.current = null;
+      });
+    }
+
+    return refreshPromiseRef.current;
+  }, [state.refreshToken, state.refreshTokenExpiresAt, logout]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = null;
+    }
+
+    if (!state.accessToken || !state.accessTokenExpiresAt) {
+      return;
+    }
+
+    const now = Date.now();
+    const expiry = state.accessTokenExpiresAt * 1000;
+    const bufferMs = 30_000;
+    const delay = Math.max(expiry - now - bufferMs, 0);
+
+    refreshTimeoutRef.current = setTimeout(() => {
+      void refreshTokens();
+    }, delay);
+
+    return () => {
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+        refreshTimeoutRef.current = null;
+      }
+    };
+  }, [state.accessToken, state.accessTokenExpiresAt, refreshTokens]);
+
+  const getValidAccessToken = useCallback(async () => {
+    if (!state.accessToken) {
+      return refreshTokens();
+    }
+
+    if (!isTokenExpired(state.accessTokenExpiresAt)) {
+      return state.accessToken;
+    }
+
+    return refreshTokens();
+  }, [state.accessToken, state.accessTokenExpiresAt, refreshTokens]);
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      login,
+      register,
+      logout,
+      getValidAccessToken
+    }),
+    [state, login, register, logout, getValidAccessToken]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+}

--- a/frontend/components/cart/CartProvider.tsx
+++ b/frontend/components/cart/CartProvider.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import type { CartEntry, Product } from '../../lib/types';
+
+interface CartContextValue {
+  items: CartEntry[];
+  totalQuantity: number;
+  totalPrice: number;
+  addItem: (product: Product, quantity: number) => void;
+  updateItemQuantity: (productId: number, quantity: number) => void;
+  removeItem: (productId: number) => void;
+  clearCart: () => void;
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'mini-marketplace-cart';
+
+function loadPersistedCart(): CartEntry[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as CartEntry[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map((entry) => ({
+      product: entry.product,
+      quantity: entry.quantity
+    }));
+  } catch (error) {
+    console.warn('Failed to parse cart state from storage', error);
+    return [];
+  }
+}
+
+function persistCart(items: CartEntry[]) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (error) {
+    console.warn('Failed to persist cart state', error);
+  }
+}
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = useState<CartEntry[]>([]);
+
+  useEffect(() => {
+    setItems(loadPersistedCart());
+  }, []);
+
+  useEffect(() => {
+    persistCart(items);
+  }, [items]);
+
+  const addItem = useCallback((product: Product, quantity: number) => {
+    setItems((prev) => {
+      const existing = prev.find((entry) => entry.product.id === product.id);
+      if (existing) {
+        return prev.map((entry) =>
+          entry.product.id === product.id
+            ? { ...entry, quantity: Math.max(1, entry.quantity + quantity) }
+            : entry
+        );
+      }
+      return [
+        ...prev,
+        {
+          product,
+          quantity: Math.max(1, quantity)
+        }
+      ];
+    });
+  }, []);
+
+  const updateItemQuantity = useCallback((productId: number, quantity: number) => {
+    setItems((prev) =>
+      prev
+        .map((entry) =>
+          entry.product.id === productId
+            ? { ...entry, quantity: Math.max(1, quantity) }
+            : entry
+        )
+        .filter((entry) => entry.quantity > 0)
+    );
+  }, []);
+
+  const removeItem = useCallback((productId: number) => {
+    setItems((prev) => prev.filter((entry) => entry.product.id !== productId));
+  }, []);
+
+  const clearCart = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const totalQuantity = useMemo(
+    () => items.reduce((total, entry) => total + entry.quantity, 0),
+    [items]
+  );
+
+  const totalPrice = useMemo(
+    () => items.reduce((total, entry) => total + (entry.product.price ?? 0) * entry.quantity, 0),
+    [items]
+  );
+
+  const value = useMemo(
+    () => ({
+      items,
+      totalQuantity,
+      totalPrice,
+      addItem,
+      updateItemQuantity,
+      removeItem,
+      clearCart
+    }),
+    [items, totalQuantity, totalPrice, addItem, updateItemQuantity, removeItem, clearCart]
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart() {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error('useCart must be used within a CartProvider');
+  }
+  return context;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,147 @@
+import type {
+  CreateOrderInput,
+  CreateOrderOutput,
+  CreateProductInput,
+  CreateProductOutput,
+  GetProductByIdOutput,
+  GetProductsOutput,
+  GetOrdersByBuyerStatusOutput,
+  LoginInput,
+  LoginOutput,
+  OrderStatus,
+  RefreshTokenOutput,
+  RegisterInput,
+  RegisterOutput
+} from './types';
+
+const DEFAULT_BASE_URL = 'http://localhost:8080';
+
+function getBaseUrl() {
+  if (process.env.NEXT_PUBLIC_API_BASE_URL) {
+    return process.env.NEXT_PUBLIC_API_BASE_URL;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+interface FetchOptions extends RequestInit {
+  token?: string | null;
+}
+
+async function apiFetch<T>(path: string, options: FetchOptions = {}): Promise<T> {
+  const { token, headers, ...rest } = options;
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers
+    },
+    cache: 'no-store'
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+  const payload = isJson ? await response.json() : undefined;
+
+  if (!response.ok) {
+    const message = (payload as { error?: string; message?: string } | undefined)?.error ??
+      (payload as { message?: string } | undefined)?.message ??
+      response.statusText;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+export async function loginRequest(input: LoginInput): Promise<LoginOutput> {
+  return apiFetch<LoginOutput>('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(input)
+  });
+}
+
+export async function registerRequest(input: RegisterInput): Promise<RegisterOutput> {
+  return apiFetch<RegisterOutput>('/auth/register', {
+    method: 'POST',
+    body: JSON.stringify(input)
+  });
+}
+
+export async function refreshTokenRequest(refreshToken: string): Promise<RefreshTokenOutput> {
+  return apiFetch<RefreshTokenOutput>('/auth/refresh-token', {
+    method: 'POST',
+    body: JSON.stringify({ refresh_token: refreshToken })
+  });
+}
+
+export async function getProductsRequest(
+  page: number,
+  pageSize: number,
+  token?: string | null
+): Promise<GetProductsOutput> {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize)
+  });
+  return apiFetch<GetProductsOutput>(`/products?${params.toString()}`, {
+    method: 'GET',
+    token
+  });
+}
+
+export async function getProductByIdRequest(
+  id: number,
+  token?: string | null
+): Promise<GetProductByIdOutput> {
+  return apiFetch<GetProductByIdOutput>(`/products/${id}`, {
+    method: 'GET',
+    token
+  });
+}
+
+export async function getProductsBySellerRequest(
+  sellerId: number,
+  token?: string | null
+): Promise<GetProductsOutput> {
+  return apiFetch<GetProductsOutput>(`/products/seller/${sellerId}`, {
+    method: 'GET',
+    token
+  });
+}
+
+export async function createProductRequest(
+  input: CreateProductInput,
+  token?: string | null
+): Promise<CreateProductOutput> {
+  return apiFetch<CreateProductOutput>('/products', {
+    method: 'POST',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
+export async function createOrderRequest(
+  input: CreateOrderInput,
+  token?: string | null
+): Promise<CreateOrderOutput> {
+  return apiFetch<CreateOrderOutput>('/orders', {
+    method: 'POST',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
+export async function getOrdersByBuyerStatusRequest(
+  buyerId: number,
+  status: OrderStatus,
+  token?: string | null
+): Promise<GetOrdersByBuyerStatusOutput> {
+  const params = new URLSearchParams({
+    buyer_id: String(buyerId),
+    status
+  });
+  return apiFetch<GetOrdersByBuyerStatusOutput>(`/orders?${params.toString()}`, {
+    method: 'GET',
+    token
+  });
+}

--- a/frontend/lib/jwt.ts
+++ b/frontend/lib/jwt.ts
@@ -1,0 +1,100 @@
+import { decodeJwt, type JWTPayload } from 'jose';
+import type { Role } from './types';
+
+interface AuthTokenPayload extends JWTPayload {
+  UserID?: number | string;
+  userID?: number | string;
+  userId?: number | string;
+  userid?: number | string;
+  sub?: number | string;
+  Username?: string;
+  username?: string;
+  Role?: string;
+  role?: string;
+  Type?: string;
+  type?: string;
+}
+
+export interface DecodedAuthToken {
+  userId: number | null;
+  username: string | null;
+  role: Role | null;
+  expiresAt: number | null;
+  tokenType: string | null;
+}
+
+const validRoles: Role[] = ['buyer', 'seller_admin', 'seller_employee'];
+
+function coerceUserId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function coerceRole(value: unknown): Role | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value as Role;
+  return validRoles.includes(normalized) ? normalized : null;
+}
+
+export function decodeAuthToken(token: string | null): DecodedAuthToken {
+  if (!token) {
+    return { userId: null, username: null, role: null, expiresAt: null, tokenType: null };
+  }
+
+  try {
+    const payload = decodeJwt(token) as AuthTokenPayload;
+    const userId =
+      coerceUserId(payload.UserID) ??
+      coerceUserId(payload.userID) ??
+      coerceUserId(payload.userId) ??
+      coerceUserId(payload.userid) ??
+      coerceUserId(payload.sub);
+
+    const username =
+      typeof payload.Username === 'string'
+        ? payload.Username
+        : typeof payload.username === 'string'
+          ? payload.username
+          : null;
+
+    const role = coerceRole(payload.Role ?? payload.role);
+
+    const expiresAt = typeof payload.exp === 'number' ? payload.exp : null;
+
+    const tokenType =
+      typeof payload.Type === 'string'
+        ? payload.Type
+        : typeof payload.type === 'string'
+          ? payload.type
+          : null;
+
+    return {
+      userId,
+      username,
+      role,
+      expiresAt,
+      tokenType
+    };
+  } catch (error) {
+    console.warn('Failed to decode auth token', error);
+    return { userId: null, username: null, role: null, expiresAt: null, tokenType: null };
+  }
+}
+
+export function isTokenExpired(expiresAt: number | null, bufferSeconds = 15): boolean {
+  if (!expiresAt) {
+    return true;
+  }
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  return expiresAt - bufferSeconds <= nowInSeconds;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,112 @@
+export type Role = 'buyer' | 'seller_admin' | 'seller_employee';
+
+export interface LoginInput {
+  username: string;
+  password: string;
+  role: Role;
+}
+
+export interface LoginOutput {
+  access_token?: string;
+  refresh_token?: string;
+  message?: string;
+  success?: boolean;
+  role?: Role;
+  username?: string;
+  user_id?: number | string;
+}
+
+export interface RefreshTokenInput {
+  refresh_token: string;
+}
+
+export interface RefreshTokenOutput {
+  access_token?: string;
+  refresh_token?: string;
+  message?: string;
+  success?: boolean;
+}
+
+export interface RegisterInput {
+  username: string;
+  password: string;
+  role: Role;
+}
+
+export interface RegisterOutput {
+  success?: boolean;
+  message?: string;
+}
+
+export interface Product {
+  id?: number;
+  name: string;
+  price: number;
+  inventory: number;
+  seller_id: number;
+  attributes?: Record<string, unknown>;
+}
+
+export interface CartEntry {
+  product: Product;
+  quantity: number;
+}
+
+export interface GetProductsOutput {
+  success?: boolean;
+  message?: string;
+  products?: Product[];
+}
+
+export interface OrderItem {
+  id?: number;
+  order_id?: number;
+  product_id: number;
+  name?: string;
+  price: number;
+  quantity: number;
+}
+
+export type OrderStatus = 'PENDING' | 'FAILED' | 'SUCCESS' | 'VALID' | 'CANCELED';
+
+export interface Order {
+  id?: number;
+  buyer_id: number;
+  status?: OrderStatus;
+  total_price?: number;
+  order_items: OrderItem[];
+}
+
+export interface CreateProductInput {
+  name: string;
+  price: number;
+  inventory: number;
+  seller_id: number;
+  attributes?: Record<string, unknown>;
+}
+
+export interface CreateProductOutput {
+  success?: boolean;
+  message?: string;
+}
+
+export interface CreateOrderInput {
+  order: Order;
+}
+
+export interface CreateOrderOutput {
+  success?: boolean;
+  message?: string;
+}
+
+export interface GetOrdersByBuyerStatusOutput {
+  success?: boolean;
+  message?: string;
+  orders?: Order[];
+}
+
+export interface GetProductByIdOutput {
+  success?: boolean;
+  message?: string;
+  product?: Product;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -67,7 +67,7 @@ export interface OrderItem {
   quantity: number;
 }
 
-export type OrderStatus = 'PENDING' | 'FAILED' | 'SUCCESS' | 'VALID' | 'CANCELED';
+export type OrderStatus = 'PENDING' | 'FAILED' | 'SUCCESS';
 
 export interface Order {
   id?: number;

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mini-marketplace-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "jose": "5.2.4",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './lib/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- hide the cart navigation entry for seller accounts so they no longer see cart controls
- restrict add-to-cart actions to buyer roles and require buyer access when opening the cart page

## Testing
- not run (npm registry access is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e386aee478832f9c8fd3034f539446