### PR TITLE
fix(frontend): redirect logout and guard pagination

### DIFF
--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -9,7 +9,7 @@ const roles: Role[] = ['buyer', 'seller_admin', 'seller_employee'];
 
 export default function RegisterPage() {
   const router = useRouter();
-  const { register } = useAuth();
+  const { register, login } = useAuth();
   const [formState, setFormState] = useState<RegisterInput>({
     username: '',
     password: '',
@@ -24,10 +24,9 @@ export default function RegisterPage() {
     setMessage(null);
     try {
       const response = await register(formState);
-      setMessage(response.message ?? 'Đăng ký thành công. Vui lòng đăng nhập.');
-      setTimeout(() => {
-        router.push('/login');
-      }, 800);
+      setMessage(response.message ?? 'Đăng ký thành công. Vui lòng hoàn thiện thông tin cá nhân.');
+      await login({ ...formState });
+      router.push('/profile?setup=1');
     } catch (err) {
       setMessage((err as Error).message);
     } finally {

--- a/frontend/app/dashboard/DashboardContent.tsx
+++ b/frontend/app/dashboard/DashboardContent.tsx
@@ -34,12 +34,7 @@ export function DashboardContent() {
             Thêm sản phẩm vào giỏ hàng từ trang <strong>Sản phẩm</strong>, sau đó truy cập mục <strong>Giỏ hàng</strong> để hoàn
             tất đơn hàng.
           </p>
-        ) : (
-          <p className="text-sm text-slate-600">
-            Chỉ tài khoản người mua mới có thể tạo đơn hàng. Bạn vẫn có thể theo dõi các yêu cầu mua hàng của khách trong hệ
-            thống quản trị hoặc xem sản phẩm của mình tại mục <strong>Sản phẩm của tôi</strong>.
-          </p>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/app/products/ProductsPageClient.tsx
+++ b/frontend/app/products/ProductsPageClient.tsx
@@ -1,17 +1,21 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getProductsRequest } from '../../lib/api';
 import type { Product } from '../../lib/types';
 import { useAuth } from '../../components/auth/AuthProvider';
 import { ProductCard } from '../../components/ProductCard';
 
 export function ProductsPageClient() {
-  const { accessToken, getValidAccessToken } = useAuth();
+  const { getValidAccessToken } = useAuth();
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
+  const lastNonEmptyPageRef = useRef(1);
+  const [finalPage, setFinalPage] = useState<number | null>(null);
+
+  const pageSize = 12;
 
   useEffect(() => {
     let cancelled = false;
@@ -24,9 +28,32 @@ export function ProductsPageClient() {
         if (!token) {
           throw new Error('Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại.');
         }
-        const response = await getProductsRequest(page, 12, token);
+        const response = await getProductsRequest(page, pageSize, token);
         if (!cancelled) {
-          setProducts(response.products ?? []);
+          const fetchedProducts = response.products ?? [];
+          if (fetchedProducts.length === 0) {
+            const fallbackLastPage = Math.max(lastNonEmptyPageRef.current, 1);
+            setProducts([]);
+            setFinalPage((previous) =>
+              previous === fallbackLastPage ? previous : fallbackLastPage
+            );
+            if (page > fallbackLastPage) {
+              setPage(fallbackLastPage);
+            }
+            return;
+          }
+
+          setProducts(fetchedProducts);
+          lastNonEmptyPageRef.current = page;
+          setFinalPage((previous) => {
+            if (fetchedProducts.length < pageSize) {
+              return previous === page ? previous : page;
+            }
+            if (previous !== null && page > previous) {
+              return null;
+            }
+            return previous;
+          });
         }
       } catch (err) {
         if (!cancelled) {
@@ -43,7 +70,9 @@ export function ProductsPageClient() {
     return () => {
       cancelled = true;
     };
-  }, [page, accessToken, getValidAccessToken]);
+  }, [page, getValidAccessToken]);
+
+  const isLastPage = finalPage !== null && page >= finalPage;
 
   return (
     <div className="grid gap-6">
@@ -65,7 +94,8 @@ export function ProductsPageClient() {
           <button
             type="button"
             onClick={() => setPage((prev) => prev + 1)}
-            className="rounded-xl border border-slate-300 px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-100"
+            className="rounded-xl border border-slate-300 px-4 py-2 font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isLastPage}
           >
             Trang sau
           </button>

--- a/frontend/app/profile/ProfilePageClient.tsx
+++ b/frontend/app/profile/ProfilePageClient.tsx
@@ -119,6 +119,7 @@ export function ProfilePageClient() {
   const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [changingPassword, setChangingPassword] = useState(false);
+  const [passwordFormVisible, setPasswordFormVisible] = useState(false);
 
   useEffect(() => {
     setBuyerForm(createEmptyBuyerForm());
@@ -533,62 +534,97 @@ export function ProfilePageClient() {
         </section>
 
         <section className="card h-max">
-          <h2 className="text-xl font-semibold text-slate-900">Đổi mật khẩu</h2>
-          <p className="text-sm text-slate-600">
-            Sử dụng mật khẩu mạnh để đảm bảo an toàn cho tài khoản của bạn.
-          </p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">Đổi mật khẩu</h2>
+              <p className="text-sm text-slate-600">
+                Sử dụng mật khẩu mạnh để đảm bảo an toàn cho tài khoản của bạn.
+              </p>
+            </div>
+            {!passwordFormVisible ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setPasswordFormVisible(true);
+                  setPasswordError(null);
+                  setPasswordMessage(null);
+                }}
+                className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+              >
+                Đổi mật khẩu
+              </button>
+            ) : null}
+          </div>
 
-          {passwordMessage ? (
-            <p className="mt-4 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{passwordMessage}</p>
-          ) : null}
-          {passwordError ? (
-            <p className="mt-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">{passwordError}</p>
-          ) : null}
+          {passwordFormVisible ? (
+            <>
+              {passwordMessage ? (
+                <p className="mt-4 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{passwordMessage}</p>
+              ) : null}
+              {passwordError ? (
+                <p className="mt-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">{passwordError}</p>
+              ) : null}
 
-          <form className="mt-6 grid gap-4" onSubmit={handlePasswordSubmit}>
-            <label className="grid gap-1 text-sm font-medium text-slate-700">
-              Mật khẩu hiện tại
-              <input
-                type="password"
-                value={passwordForm.oldPassword}
-                onChange={(event) =>
-                  setPasswordForm((prev) => ({ ...prev, oldPassword: event.target.value }))
-                }
-                required
-              />
-            </label>
-            <label className="grid gap-1 text-sm font-medium text-slate-700">
-              Mật khẩu mới
-              <input
-                type="password"
-                value={passwordForm.newPassword}
-                minLength={6}
-                onChange={(event) =>
-                  setPasswordForm((prev) => ({ ...prev, newPassword: event.target.value }))
-                }
-                required
-              />
-            </label>
-            <label className="grid gap-1 text-sm font-medium text-slate-700">
-              Nhập lại mật khẩu mới
-              <input
-                type="password"
-                value={passwordForm.confirmPassword}
-                minLength={6}
-                onChange={(event) =>
-                  setPasswordForm((prev) => ({ ...prev, confirmPassword: event.target.value }))
-                }
-                required
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={changingPassword}
-              className="rounded-xl bg-slate-900 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {changingPassword ? 'Đang xử lý...' : 'Cập nhật mật khẩu'}
-            </button>
-          </form>
+              <form className="mt-6 grid gap-4" onSubmit={handlePasswordSubmit}>
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Mật khẩu hiện tại
+                  <input
+                    type="password"
+                    value={passwordForm.oldPassword}
+                    onChange={(event) =>
+                      setPasswordForm((prev) => ({ ...prev, oldPassword: event.target.value }))
+                    }
+                    required
+                  />
+                </label>
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Mật khẩu mới
+                  <input
+                    type="password"
+                    value={passwordForm.newPassword}
+                    minLength={6}
+                    onChange={(event) =>
+                      setPasswordForm((prev) => ({ ...prev, newPassword: event.target.value }))
+                    }
+                    required
+                  />
+                </label>
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Nhập lại mật khẩu mới
+                  <input
+                    type="password"
+                    value={passwordForm.confirmPassword}
+                    minLength={6}
+                    onChange={(event) =>
+                      setPasswordForm((prev) => ({ ...prev, confirmPassword: event.target.value }))
+                    }
+                    required
+                  />
+                </label>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="submit"
+                    disabled={changingPassword}
+                    className="rounded-xl bg-slate-900 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {changingPassword ? 'Đang xử lý...' : 'Cập nhật mật khẩu'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPasswordFormVisible(false);
+                      setPasswordForm({ oldPassword: '', newPassword: '', confirmPassword: '' });
+                      setPasswordError(null);
+                      setPasswordMessage(null);
+                    }}
+                    className="rounded-xl border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300"
+                  >
+                    Huỷ
+                  </button>
+                </div>
+              </form>
+            </>
+          ) : null}
         </section>
       </div>
     </div>

--- a/frontend/app/profile/ProfilePageClient.tsx
+++ b/frontend/app/profile/ProfilePageClient.tsx
@@ -1,0 +1,596 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useAuth } from '../../components/auth/AuthProvider';
+import {
+  changePasswordRequest,
+  createBuyerProfileRequest,
+  createSellerProfileRequest,
+  getBuyerProfileRequest,
+  getSellerProfileRequest,
+  updateBuyerProfileRequest,
+  updateSellerProfileRequest
+} from '../../lib/api';
+import type { BuyerProfile, SellerProfile } from '../../lib/types';
+
+const genderOptions = [
+  { value: 'male', label: 'Nam' },
+  { value: 'female', label: 'Nữ' },
+  { value: 'other', label: 'Khác' }
+];
+
+interface BuyerFormState {
+  name: string;
+  gender: string;
+  date_of_birth: string;
+  phone: string;
+  address: string;
+}
+
+interface SellerFormState {
+  name: string;
+  bank_account: string;
+  tax_code: string;
+  description: string;
+  date_of_birth: string;
+  phone: string;
+  address: string;
+}
+
+interface PasswordFormState {
+  oldPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+function createEmptyBuyerForm(): BuyerFormState {
+  return {
+    name: '',
+    gender: 'other',
+    date_of_birth: '',
+    phone: '',
+    address: ''
+  };
+}
+
+function createEmptySellerForm(): SellerFormState {
+  return {
+    name: '',
+    bank_account: '',
+    tax_code: '',
+    description: '',
+    date_of_birth: '',
+    phone: '',
+    address: ''
+  };
+}
+
+function formatDateInput(value?: string | null) {
+  if (!value) {
+    return '';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toISOString().split('T')[0] ?? '';
+}
+
+function ensureIsoDate(value: string) {
+  if (!value) {
+    throw new Error('Vui lòng chọn ngày sinh.');
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Ngày sinh không hợp lệ.');
+  }
+  return date.toISOString();
+}
+
+function isNotFoundMessage(message: string) {
+  return /not\s+found/i.test(message);
+}
+
+export function ProfilePageClient() {
+  const searchParams = useSearchParams();
+  const { role, userId, username, getValidAccessToken } = useAuth();
+  const isSetupFlow = useMemo(() => {
+    if (!searchParams) {
+      return false;
+    }
+    const value = searchParams.get('setup');
+    return value !== null;
+  }, [searchParams]);
+
+  const [buyerForm, setBuyerForm] = useState<BuyerFormState>(createEmptyBuyerForm);
+  const [sellerForm, setSellerForm] = useState<SellerFormState>(createEmptySellerForm);
+  const [profileExists, setProfileExists] = useState(false);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [profileMessage, setProfileMessage] = useState<string | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [savingProfile, setSavingProfile] = useState(false);
+
+  const [passwordForm, setPasswordForm] = useState<PasswordFormState>({
+    oldPassword: '',
+    newPassword: '',
+    confirmPassword: ''
+  });
+  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [changingPassword, setChangingPassword] = useState(false);
+
+  useEffect(() => {
+    setBuyerForm(createEmptyBuyerForm());
+    setSellerForm(createEmptySellerForm());
+    setProfileExists(false);
+    setProfileMessage(null);
+    setProfileError(null);
+  }, [role]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProfile() {
+      if (!userId || !role) {
+        setLoadingProfile(false);
+        return;
+      }
+
+      setLoadingProfile(true);
+      setProfileMessage(null);
+      setProfileError(null);
+
+      try {
+        const token = await getValidAccessToken();
+        if (!token) {
+          throw new Error('Không thể xác thực. Vui lòng đăng nhập lại.');
+        }
+
+        if (role === 'buyer') {
+          const response = await getBuyerProfileRequest(userId, token);
+          if (cancelled) {
+            return;
+          }
+          if (response?.buyer) {
+            const buyer: BuyerProfile = response.buyer;
+            setBuyerForm({
+              name: buyer.name ?? '',
+              gender: buyer.gender ?? 'other',
+              date_of_birth: formatDateInput(buyer.date_of_birth),
+              phone: buyer.phone ?? '',
+              address: buyer.address ?? ''
+            });
+            setProfileExists(true);
+          } else {
+            setProfileExists(false);
+          }
+        } else if (role === 'seller_admin' || role === 'seller_employee') {
+          const response = await getSellerProfileRequest(userId, token);
+          if (cancelled) {
+            return;
+          }
+          if (response?.seller) {
+            const seller: SellerProfile = response.seller;
+            setSellerForm({
+              name: seller.name ?? '',
+              bank_account: seller.bank_account ?? '',
+              tax_code: seller.tax_code ?? '',
+              description: seller.description ?? '',
+              date_of_birth: formatDateInput(seller.date_of_birth),
+              phone: seller.phone ?? '',
+              address: seller.address ?? ''
+            });
+            setProfileExists(true);
+          } else {
+            setProfileExists(false);
+          }
+        } else {
+          setProfileExists(false);
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : 'Không thể tải thông tin cá nhân.';
+        if (isNotFoundMessage(message)) {
+          setProfileExists(false);
+          setProfileError(null);
+        } else {
+          setProfileError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingProfile(false);
+        }
+      }
+    }
+
+    void loadProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, role, getValidAccessToken]);
+
+  const isBuyer = role === 'buyer';
+  const isSeller = role === 'seller_admin' || role === 'seller_employee';
+  const canEditProfile = isBuyer || isSeller;
+  const profileTitle = isBuyer
+    ? 'Thông tin người mua'
+    : isSeller
+      ? 'Thông tin nhà bán hàng'
+      : 'Thông tin cá nhân';
+  const profileSubtitle = isBuyer
+    ? 'Điền chính xác thông tin để thuận tiện trong quá trình mua hàng.'
+    : isSeller
+      ? 'Cập nhật đầy đủ thông tin cửa hàng để tăng độ tin cậy với khách hàng.'
+      : 'Vai trò hiện tại chưa hỗ trợ cập nhật chi tiết thông tin.';
+
+  const handleBuyerSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!userId) {
+      setProfileError('Không xác định được người dùng.');
+      return;
+    }
+
+    setSavingProfile(true);
+    setProfileMessage(null);
+    setProfileError(null);
+
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        throw new Error('Không thể xác thực. Vui lòng đăng nhập lại.');
+      }
+      const dateOfBirth = ensureIsoDate(buyerForm.date_of_birth);
+      const payload: BuyerProfile = {
+        user_id: userId,
+        name: buyerForm.name.trim(),
+        gender: buyerForm.gender.trim(),
+        date_of_birth: dateOfBirth,
+        phone: buyerForm.phone.trim(),
+        address: buyerForm.address.trim()
+      };
+
+      if (profileExists) {
+        await updateBuyerProfileRequest(userId, { buyer: payload }, token);
+        setProfileMessage('Cập nhật thông tin cá nhân thành công.');
+      } else {
+        await createBuyerProfileRequest({ buyer: payload }, token);
+        setProfileExists(true);
+        setProfileMessage('Đã lưu thông tin cá nhân.');
+      }
+    } catch (error) {
+      setProfileError(error instanceof Error ? error.message : 'Không thể lưu thông tin cá nhân.');
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handleSellerSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!userId) {
+      setProfileError('Không xác định được người dùng.');
+      return;
+    }
+
+    setSavingProfile(true);
+    setProfileMessage(null);
+    setProfileError(null);
+
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        throw new Error('Không thể xác thực. Vui lòng đăng nhập lại.');
+      }
+      const dateOfBirth = ensureIsoDate(sellerForm.date_of_birth);
+      const payload: SellerProfile = {
+        name: sellerForm.name.trim(),
+        bank_account: sellerForm.bank_account.trim(),
+        tax_code: sellerForm.tax_code.trim(),
+        description: sellerForm.description.trim(),
+        date_of_birth: dateOfBirth,
+        phone: sellerForm.phone.trim(),
+        address: sellerForm.address.trim()
+      };
+
+      if (profileExists) {
+        await updateSellerProfileRequest(userId, { seller: payload, user_id: userId }, token);
+        setProfileMessage('Cập nhật thông tin cửa hàng thành công.');
+      } else {
+        await createSellerProfileRequest({ seller: payload, user_id: userId }, token);
+        setProfileExists(true);
+        setProfileMessage('Đã lưu thông tin cửa hàng.');
+      }
+    } catch (error) {
+      setProfileError(error instanceof Error ? error.message : 'Không thể lưu thông tin cửa hàng.');
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordError(null);
+    setPasswordMessage(null);
+
+    if (!username || !role) {
+      setPasswordError('Không xác định được tài khoản.');
+      return;
+    }
+    if (!passwordForm.oldPassword || !passwordForm.newPassword) {
+      setPasswordError('Vui lòng nhập đầy đủ mật khẩu cũ và mật khẩu mới.');
+      return;
+    }
+    if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+      setPasswordError('Mật khẩu mới không khớp.');
+      return;
+    }
+
+    setChangingPassword(true);
+    try {
+      const token = await getValidAccessToken();
+      if (!token) {
+        throw new Error('Không thể xác thực. Vui lòng đăng nhập lại.');
+      }
+      const response = await changePasswordRequest(
+        {
+          username,
+          old_password: passwordForm.oldPassword,
+          new_password: passwordForm.newPassword,
+          role
+        },
+        token
+      );
+      setPasswordMessage(response.message ?? 'Đổi mật khẩu thành công.');
+      setPasswordForm({ oldPassword: '', newPassword: '', confirmPassword: '' });
+    } catch (error) {
+      setPasswordError(error instanceof Error ? error.message : 'Không thể đổi mật khẩu.');
+    } finally {
+      setChangingPassword(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-8 px-4 py-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-slate-900">Thông tin cá nhân</h1>
+        <p className="text-sm text-slate-600">
+          Quản lý dữ liệu cá nhân và cập nhật mật khẩu để bảo vệ tài khoản của bạn.
+        </p>
+        {isSetupFlow ? (
+          <p className="rounded-xl bg-indigo-50 px-4 py-2 text-sm text-indigo-700">
+            Đăng ký thành công! Vui lòng hoàn thiện thông tin bên dưới để bắt đầu sử dụng hệ thống.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="card">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">{profileTitle}</h2>
+              <p className="text-sm text-slate-600">{profileSubtitle}</p>
+            </div>
+            {loadingProfile ? <span className="text-xs font-medium text-slate-500">Đang tải...</span> : null}
+          </div>
+
+          {profileMessage ? (
+            <p className="mt-4 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{profileMessage}</p>
+          ) : null}
+          {profileError ? (
+            <p className="mt-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">{profileError}</p>
+          ) : null}
+
+          {canEditProfile ? (
+            <form
+              className="mt-6 grid gap-4"
+              onSubmit={isBuyer ? handleBuyerSubmit : handleSellerSubmit}
+            >
+              <label className="grid gap-1 text-sm font-medium text-slate-700">
+                Họ và tên
+                <input
+                  type="text"
+                  value={isBuyer ? buyerForm.name : sellerForm.name}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (isBuyer) {
+                      setBuyerForm((prev) => ({ ...prev, name: value }));
+                    } else {
+                      setSellerForm((prev) => ({ ...prev, name: value }));
+                    }
+                  }}
+                  required
+                />
+              </label>
+
+              {isBuyer ? (
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Giới tính
+                  <select
+                    value={buyerForm.gender}
+                    onChange={(event) =>
+                      setBuyerForm((prev) => ({ ...prev, gender: event.target.value }))
+                    }
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  >
+                    {genderOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : (
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Tài khoản ngân hàng
+                  <input
+                    type="text"
+                    value={sellerForm.bank_account}
+                    onChange={(event) =>
+                      setSellerForm((prev) => ({ ...prev, bank_account: event.target.value }))
+                    }
+                    placeholder="Ví dụ: 0123456789 - Ngân hàng A"
+                    required
+                  />
+                </label>
+              )}
+
+              <label className="grid gap-1 text-sm font-medium text-slate-700">
+                Ngày sinh
+                <input
+                  type="date"
+                  value={isBuyer ? buyerForm.date_of_birth : sellerForm.date_of_birth}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (isBuyer) {
+                      setBuyerForm((prev) => ({ ...prev, date_of_birth: value }));
+                    } else {
+                      setSellerForm((prev) => ({ ...prev, date_of_birth: value }));
+                    }
+                  }}
+                  required
+                />
+              </label>
+
+              <label className="grid gap-1 text-sm font-medium text-slate-700">
+                Số điện thoại
+                <input
+                  type="tel"
+                  value={isBuyer ? buyerForm.phone : sellerForm.phone}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (isBuyer) {
+                      setBuyerForm((prev) => ({ ...prev, phone: value }));
+                    } else {
+                      setSellerForm((prev) => ({ ...prev, phone: value }));
+                    }
+                  }}
+                  required
+                />
+              </label>
+
+              {isSeller ? (
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Mã số thuế
+                  <input
+                    type="text"
+                    value={sellerForm.tax_code}
+                    onChange={(event) =>
+                      setSellerForm((prev) => ({ ...prev, tax_code: event.target.value }))
+                    }
+                    required
+                  />
+                </label>
+              ) : null}
+
+              <label className="grid gap-1 text-sm font-medium text-slate-700">
+                Địa chỉ
+                <textarea
+                  value={isBuyer ? buyerForm.address : sellerForm.address}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (isBuyer) {
+                      setBuyerForm((prev) => ({ ...prev, address: value }));
+                    } else {
+                      setSellerForm((prev) => ({ ...prev, address: value }));
+                    }
+                  }}
+                  rows={3}
+                  required
+                />
+              </label>
+
+              {isSeller ? (
+                <label className="grid gap-1 text-sm font-medium text-slate-700">
+                  Mô tả cửa hàng
+                  <textarea
+                    value={sellerForm.description}
+                    onChange={(event) =>
+                      setSellerForm((prev) => ({ ...prev, description: event.target.value }))
+                    }
+                    rows={3}
+                    placeholder="Giới thiệu ngắn gọn về cửa hàng của bạn"
+                    required
+                  />
+                </label>
+              ) : null}
+
+              <button
+                type="submit"
+                disabled={savingProfile || loadingProfile}
+                className="mt-2 rounded-xl bg-indigo-600 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {savingProfile ? 'Đang lưu...' : profileExists ? 'Cập nhật thông tin' : 'Lưu thông tin'}
+              </button>
+            </form>
+          ) : (
+            <p className="mt-6 rounded-lg bg-slate-100 px-3 py-2 text-sm text-slate-600">
+              Vai trò hiện tại chưa hỗ trợ cập nhật thông tin cá nhân. Vui lòng liên hệ quản trị viên nếu bạn cần hỗ trợ.
+            </p>
+          )}
+        </section>
+
+        <section className="card h-max">
+          <h2 className="text-xl font-semibold text-slate-900">Đổi mật khẩu</h2>
+          <p className="text-sm text-slate-600">
+            Sử dụng mật khẩu mạnh để đảm bảo an toàn cho tài khoản của bạn.
+          </p>
+
+          {passwordMessage ? (
+            <p className="mt-4 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{passwordMessage}</p>
+          ) : null}
+          {passwordError ? (
+            <p className="mt-4 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">{passwordError}</p>
+          ) : null}
+
+          <form className="mt-6 grid gap-4" onSubmit={handlePasswordSubmit}>
+            <label className="grid gap-1 text-sm font-medium text-slate-700">
+              Mật khẩu hiện tại
+              <input
+                type="password"
+                value={passwordForm.oldPassword}
+                onChange={(event) =>
+                  setPasswordForm((prev) => ({ ...prev, oldPassword: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-medium text-slate-700">
+              Mật khẩu mới
+              <input
+                type="password"
+                value={passwordForm.newPassword}
+                minLength={6}
+                onChange={(event) =>
+                  setPasswordForm((prev) => ({ ...prev, newPassword: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-medium text-slate-700">
+              Nhập lại mật khẩu mới
+              <input
+                type="password"
+                value={passwordForm.confirmPassword}
+                minLength={6}
+                onChange={(event) =>
+                  setPasswordForm((prev) => ({ ...prev, confirmPassword: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={changingPassword}
+              className="rounded-xl bg-slate-900 px-5 py-2.5 font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {changingPassword ? 'Đang xử lý...' : 'Cập nhật mật khẩu'}
+            </button>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,0 +1,10 @@
+import { ProtectedContent } from '../../components/ProtectedContent';
+import { ProfilePageClient } from './ProfilePageClient';
+
+export default function ProfilePage() {
+  return (
+    <ProtectedContent>
+      <ProfilePageClient />
+    </ProtectedContent>
+  );
+}

--- a/frontend/components/CreateProductForm.tsx
+++ b/frontend/components/CreateProductForm.tsx
@@ -182,17 +182,19 @@ export function CreateProductForm() {
               required
             />
           </label>
-          <label className="grid gap-2 text-sm font-medium text-slate-700">
-            Mã người bán
+          <label className="grid gap-1 text-sm font-medium text-slate-700">
+            <span>Mã người bán</span>
             <input
               type="number"
               value={formState.seller_id}
-              onChange={(event) =>
-                setFormState((prev) => ({ ...prev, seller_id: Number(event.target.value) || 0 }))
-              }
+              readOnly
               min={1}
               required
+              className="cursor-not-allowed bg-slate-100"
             />
+            <span className="text-xs font-normal text-slate-500">
+              Trường này được liên kết với tài khoản hiện tại và không thể thay đổi.
+            </span>
           </label>
           <div className="grid gap-3">
             <div className="flex items-center justify-between">

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useAuth } from './auth/AuthProvider';
 import { useCart } from './cart/CartProvider';
 import type { Role } from '../lib/types';
@@ -28,17 +28,20 @@ const baseLinks: NavLink[] = [
     requiresAuth: true,
     hiddenForRoles: ['seller_admin', 'seller_employee']
   },
+  { href: '/profile', label: 'Thông tin cá nhân', requiresAuth: true },
   { href: '/dashboard', label: 'Bảng điều khiển', requiresAuth: true, hiddenForRoles: ['buyer'] }
 ];
 
 export function NavBar() {
   const pathname = usePathname();
+  const router = useRouter();
   const { accessToken, username, role, logout } = useAuth();
   const { totalQuantity, clearCart } = useCart();
 
   const handleLogout = () => {
     clearCart();
     logout();
+    router.push('/');
   };
 
   const normalizedRole = role ?? null;
@@ -66,7 +69,7 @@ export function NavBar() {
             return true;
           })
           .map((link) => {
-            const isActive = pathname === link.href;
+            const isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
             return (
               <Link
                 key={link.href}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,17 +1,29 @@
 import type {
+  ChangePasswordInput,
+  ChangePasswordOutput,
+  CreateBuyerProfileInput,
+  CreateBuyerProfileOutput,
   CreateOrderInput,
   CreateOrderOutput,
   CreateProductInput,
   CreateProductOutput,
+  CreateSellerProfileInput,
+  CreateSellerProfileOutput,
+  GetBuyerProfileOutput,
+  GetOrdersByBuyerStatusOutput,
   GetProductByIdOutput,
   GetProductsOutput,
-  GetOrdersByBuyerStatusOutput,
+  GetSellerProfileOutput,
   LoginInput,
   LoginOutput,
   OrderStatus,
   RefreshTokenOutput,
   RegisterInput,
-  RegisterOutput
+  RegisterOutput,
+  UpdateBuyerProfileInput,
+  UpdateBuyerProfileOutput,
+  UpdateSellerProfileInput,
+  UpdateSellerProfileOutput
 } from './types';
 
 const DEFAULT_BASE_URL = 'http://localhost:8080';
@@ -67,10 +79,87 @@ export async function registerRequest(input: RegisterInput): Promise<RegisterOut
   });
 }
 
+export async function changePasswordRequest(
+  input: ChangePasswordInput,
+  token?: string | null
+): Promise<ChangePasswordOutput> {
+  return apiFetch<ChangePasswordOutput>('/auth/change-password', {
+    method: 'POST',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
 export async function refreshTokenRequest(refreshToken: string): Promise<RefreshTokenOutput> {
   return apiFetch<RefreshTokenOutput>('/auth/refresh-token', {
     method: 'POST',
     body: JSON.stringify({ refresh_token: refreshToken })
+  });
+}
+
+export async function createBuyerProfileRequest(
+  input: CreateBuyerProfileInput,
+  token?: string | null
+): Promise<CreateBuyerProfileOutput> {
+  return apiFetch<CreateBuyerProfileOutput>('/users/buyers', {
+    method: 'POST',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
+export async function getBuyerProfileRequest(
+  userId: number,
+  token?: string | null
+): Promise<GetBuyerProfileOutput> {
+  return apiFetch<GetBuyerProfileOutput>(`/users/buyers/${userId}`, {
+    method: 'GET',
+    token
+  });
+}
+
+export async function updateBuyerProfileRequest(
+  userId: number,
+  input: UpdateBuyerProfileInput,
+  token?: string | null
+): Promise<UpdateBuyerProfileOutput> {
+  return apiFetch<UpdateBuyerProfileOutput>(`/users/buyers/${userId}`, {
+    method: 'PUT',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
+export async function createSellerProfileRequest(
+  input: CreateSellerProfileInput,
+  token?: string | null
+): Promise<CreateSellerProfileOutput> {
+  return apiFetch<CreateSellerProfileOutput>('/users/sellers', {
+    method: 'POST',
+    body: JSON.stringify(input),
+    token
+  });
+}
+
+export async function getSellerProfileRequest(
+  userId: number,
+  token?: string | null
+): Promise<GetSellerProfileOutput> {
+  return apiFetch<GetSellerProfileOutput>(`/users/sellers/${userId}`, {
+    method: 'GET',
+    token
+  });
+}
+
+export async function updateSellerProfileRequest(
+  userId: number,
+  input: UpdateSellerProfileInput,
+  token?: string | null
+): Promise<UpdateSellerProfileOutput> {
+  return apiFetch<UpdateSellerProfileOutput>(`/users/sellers/${userId}`, {
+    method: 'PUT',
+    body: JSON.stringify(input),
+    token
   });
 }
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -38,6 +38,74 @@ export interface RegisterOutput {
   message?: string;
 }
 
+export interface ChangePasswordInput {
+  username: string;
+  old_password: string;
+  new_password: string;
+  role: Role;
+}
+
+export interface ChangePasswordOutput {
+  success?: boolean;
+  message?: string;
+}
+
+export interface BuyerProfile {
+  user_id: number;
+  name: string;
+  gender: string;
+  date_of_birth: string;
+  phone: string;
+  address: string;
+}
+
+export interface BuyerProfilePayload {
+  buyer: BuyerProfile;
+}
+
+export interface BuyerProfileResponse {
+  success?: boolean;
+  message?: string;
+  buyer?: BuyerProfile;
+}
+
+export type CreateBuyerProfileInput = BuyerProfilePayload;
+export type UpdateBuyerProfileInput = BuyerProfilePayload;
+export type CreateBuyerProfileOutput = BuyerProfileResponse;
+export type UpdateBuyerProfileOutput = BuyerProfileResponse;
+export type GetBuyerProfileOutput = BuyerProfileResponse;
+
+export interface SellerProfile {
+  id?: number;
+  name: string;
+  bank_account: string;
+  tax_code: string;
+  description: string;
+  date_of_birth: string;
+  phone: string;
+  address: string;
+}
+
+export interface CreateSellerProfileInput {
+  seller: SellerProfile;
+  user_id: number;
+}
+
+export interface UpdateSellerProfileInput {
+  seller: SellerProfile;
+  user_id?: number;
+}
+
+export interface SellerProfileResponse {
+  success?: boolean;
+  message?: string;
+  seller?: SellerProfile;
+}
+
+export type CreateSellerProfileOutput = SellerProfileResponse;
+export type UpdateSellerProfileOutput = SellerProfileResponse;
+export type GetSellerProfileOutput = SellerProfileResponse;
+
 export interface Product {
   id?: number;
   name: string;


### PR DESCRIPTION
## Summary
- add a protected profile area with forms to capture buyer and seller details and support password updates
- redirect new registrants to the profile setup flow and expose a personal information link in the navigation bar
- extend frontend types and API helpers for profile CRUD and password change requests
- redirect users to the homepage after logging out and prevent advancing pagination beyond the final product page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ec83403328832f982c215ee265f8ae